### PR TITLE
SkillHub P0: registry and curated bundles

### DIFF
--- a/.github/workflows/lint-skills.yml
+++ b/.github/workflows/lint-skills.yml
@@ -14,3 +14,6 @@ jobs:
 
       - name: Validate skill files
         run: python3 scripts/validate-skills.py
+
+      - name: Check registry sync
+        run: python3 scripts/generate-registry.py --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this repository are documented here.
 
 ### Added
 
+- SkillHub registry: `registry/skills.json`, `registry/bundles.json`, `scripts/generate-registry.py`
+- Bundle resolver: `scripts/resolve-bundle.py`; per-skill install: `scripts/install/install-skill.sh`
+- Bundles: `ship-ready`, `agent-builder`, `data-scientist`, `security-reviewer` (plus existing `starter`, `full`)
 - Install scripts: `scripts/install/install-domain.sh`, `scripts/install/install-bundle.sh`
 - Validation script: `scripts/validate-skills.py` (used in CI)
 - Metrics script: `scripts/repo-metrics.py`

--- a/README.md
+++ b/README.md
@@ -78,8 +78,16 @@ Install with scripts (recommended):
 # Starter bundle: core-workflow + security + reliability
 bash scripts/install/install-bundle.sh starter /path/to/project --format both
 
-# Single domain
+# Curated bundles (see registry/bundles.json)
+bash scripts/install/install-bundle.sh ship-ready /path/to/project --format both
+bash scripts/install/install-bundle.sh agent-builder /path/to/project --format cursor
+
+# Single domain or skill
 bash scripts/install/install-domain.sh core-workflow /path/to/project --format cursor
+bash scripts/install/install-skill.sh core-workflow/verify-before-done /path/to/project --format cursor
+
+# Regenerate skill index after adding skills
+python3 scripts/generate-registry.py
 ```
 
 Manual install (Cursor):

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -10,6 +10,12 @@ Track submissions to awesome lists and external roundups.
 | MCP awesome lists | mcp | Planned | | Highlight `mcp-builder`, `mcp-ecosystem-optimizer` |
 | Reddit / HN launch | social | Planned | | Post after v2.0.0 release + topics set |
 
+## SkillHub registry (P0)
+
+- `registry/skills.json` — generated index (`python3 scripts/generate-registry.py`)
+- `registry/bundles.json` — curated bundles for `install-bundle.sh`
+- CI runs `generate-registry.py --check` on every PR
+
 ## Suggested blurb
 
 > **awesome-agent-skill** — 170+ portable agent skills (planning, QA, security, MCP, browser automation, data/docs) for Cursor and Claude Code. Copy domains or use install scripts.

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,0 +1,26 @@
+# SkillHub Registry
+
+Machine-readable metadata for SkillHub CLI, web catalog, and MCP server.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `skills.json` | Generated index of all Cursor skills (do not edit by hand) |
+| `bundles.json` | Curated install bundles (edit when adding bundles) |
+
+## Regenerate skills index
+
+```bash
+python3 scripts/generate-registry.py
+```
+
+Run after adding or changing skills under `.cursor/skills/`. CI should keep `skills.json` in sync.
+
+## Bundle format
+
+Each bundle may define:
+
+- `domains`: install entire top-level folders
+- `skills`: explicit skill ids (e.g. `core-workflow/verify-before-done`)
+- `install_all_domains`: set true only for `full` bundle

--- a/registry/bundles.json
+++ b/registry/bundles.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "bundles": [
+    {
+      "id": "starter",
+      "title": "Starter",
+      "description": "Core workflow, security, and reliability skills for everyday agent-assisted development.",
+      "domains": ["core-workflow", "security-appsec", "reliability-ops"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "ship-ready",
+      "title": "Ship Ready",
+      "description": "Spec, plan, implement, test, verify, and review before merge.",
+      "domains": [],
+      "skills": [
+        "core-workflow/spec-driven-development",
+        "core-workflow/planning-and-task-breakdown",
+        "core-workflow/incremental-implementation",
+        "core-workflow/test-first-development",
+        "core-workflow/verify-before-done",
+        "core-workflow/receiving-code-review",
+        "reliability-ops/shipping-launch-checklist"
+      ],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "agent-builder",
+      "title": "Agent Builder",
+      "description": "Build and evaluate agent tools, MCP servers, RAG, and context workflows.",
+      "domains": [],
+      "skills": [
+        "ai-agent-systems/mcp-builder",
+        "ai-agent-systems/agent-tool-contracts",
+        "ai-agent-systems/agent-evaluation",
+        "ai-agent-systems/rag-systems",
+        "ai-agent-systems/context-window-management"
+      ],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "data-scientist",
+      "title": "Data Scientist",
+      "description": "EDA, ML/DL, statistics, visualization, and notebook-friendly workflows.",
+      "domains": [
+        "eda-research",
+        "ml-dl",
+        "analysis-stats",
+        "data-compute",
+        "visualization"
+      ],
+      "skills": [],
+      "formats": ["cursor", "claude"]
+    },
+    {
+      "id": "security-reviewer",
+      "title": "Security Reviewer",
+      "description": "API security testing, secure design, and skill supply-chain audit.",
+      "domains": ["security-appsec"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "full",
+      "title": "Full Catalog",
+      "description": "All top-level skill domains in this repository.",
+      "domains": [],
+      "skills": [],
+      "install_all_domains": true,
+      "formats": ["cursor", "claude", "both"]
+    }
+  ]
+}

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -1,0 +1,3954 @@
+{
+  "generated_at": "2026-05-25T10:19:21Z",
+  "schema_version": 1,
+  "count": 173,
+  "skills": [
+    {
+      "id": "ai-agent-systems/agent-evaluation",
+      "name": "agent-evaluation",
+      "domain": "ai-agent-systems",
+      "path": ".cursor/skills/ai-agent-systems/agent-evaluation/SKILL.md",
+      "description": ">   Evaluate LLM agents and tool-using workflows—task success, tool accuracy,   latency/cost, safety, and regression suites. Use when shipping agent features,   comparing prompts/models, or debugging agent failures.   Triggers: \"agent eval\", \"benchmark agent\", \"tool accuracy\", \"agent regression\".",
+      "triggers": [
+        "agent eval",
+        "benchmark agent",
+        "tool accuracy",
+        "agent regression"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "agents",
+        "mcp",
+        "rag",
+        "tools",
+        "agent-evaluation"
+      ]
+    },
+    {
+      "id": "ai-agent-systems/agent-tool-contracts",
+      "name": "agent-tool-contracts",
+      "domain": "ai-agent-systems",
+      "path": ".cursor/skills/ai-agent-systems/agent-tool-contracts/SKILL.md",
+      "description": ">   Design agent tools and CLI surfaces—schemas, naming, errors, idempotency, and   discoverability for LLM callers. Use when defining tools for agents, SDKs,   or AI-native CLIs.   Triggers: \"tool schema\", \"agent tool\", \"function calling\", \"AI CLI\".",
+      "triggers": [
+        "tool schema",
+        "agent tool",
+        "function calling",
+        "AI CLI"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "agents",
+        "mcp",
+        "rag",
+        "tools",
+        "agent-tool-contracts"
+      ]
+    },
+    {
+      "id": "ai-agent-systems/context-window-management",
+      "name": "context-window-management",
+      "domain": "ai-agent-systems",
+      "path": ".cursor/skills/ai-agent-systems/context-window-management/SKILL.md",
+      "description": ">   Manage LLM context budgets—prioritization, summarization, compaction, and   what to load vs reference. Use for long sessions, large repos, or multi-doc tasks.   Triggers: \"context window\", \"too long\", \"summarize context\", \"token budget\".",
+      "triggers": [
+        "context window",
+        "too long",
+        "summarize context",
+        "token budget"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "agents",
+        "mcp",
+        "rag",
+        "tools",
+        "context-window-management"
+      ]
+    },
+    {
+      "id": "ai-agent-systems/mcp-builder",
+      "name": "mcp-builder",
+      "domain": "ai-agent-systems",
+      "path": ".cursor/skills/ai-agent-systems/mcp-builder/SKILL.md",
+      "description": ">   Design and implement MCP servers—tools, resources, prompts, schemas, and error   contracts for agent clients. Use when adding MCP integration or exposing   capabilities to Cursor/Claude agents.   Triggers: \"MCP server\", \"MCP tool\", \"Model Context Protocol\", \"build MCP\".",
+      "triggers": [
+        "MCP server",
+        "MCP tool",
+        "Model Context Protocol",
+        "build MCP"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "agents",
+        "mcp",
+        "rag",
+        "tools",
+        "mcp-builder"
+      ]
+    },
+    {
+      "id": "ai-agent-systems/mcp-ecosystem-optimizer",
+      "name": "mcp-ecosystem-optimizer",
+      "domain": "ai-agent-systems",
+      "path": ".cursor/skills/ai-agent-systems/mcp-ecosystem-optimizer/SKILL.md",
+      "description": "Review and optimize MCP server setup—inventory, registry hygiene, config, versioning, and observability. Use when managing multiple MCP servers in Cursor or Claude. Triggers: \"MCP server\", \"MCP config\", \"MCP registry\", \"optimize MCP\", \"too many MCP tools\".",
+      "triggers": [
+        "MCP server",
+        "MCP config",
+        "MCP registry",
+        "optimize MCP",
+        "too many MCP tools"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "agents",
+        "mcp",
+        "rag",
+        "tools",
+        "mcp-ecosystem-optimizer"
+      ]
+    },
+    {
+      "id": "ai-agent-systems/rag-systems",
+      "name": "rag-systems",
+      "domain": "ai-agent-systems",
+      "path": ".cursor/skills/ai-agent-systems/rag-systems/SKILL.md",
+      "description": ">   Design retrieval-augmented generation pipelines—chunking, embeddings, retrieval,   reranking, grounding, and evaluation. Use when building or improving doc Q&A,   code search agents, or knowledge bases.   Triggers: \"RAG\", \"vector search\", \"embeddings\", \"retrieval\", \"knowledge base\".",
+      "triggers": [
+        "RAG",
+        "vector search",
+        "embeddings",
+        "retrieval",
+        "knowledge base"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "agents",
+        "mcp",
+        "rag",
+        "tools",
+        "rag-systems"
+      ]
+    },
+    {
+      "id": "analysis-stats/shap",
+      "name": "shap",
+      "domain": "analysis-stats",
+      "path": ".cursor/skills/analysis-stats/shap/SKILL.md",
+      "description": "Model interpretability and explainability using SHAP (SHapley Additive exPlanations). Use this skill when explaining machine learning model predictions, computing feature importance, generating SHAP plots (waterfall, beeswarm, bar, scatter, force, heatmap), debugging models, analyzing model bias or fairness, comparing models, or implementing explainable AI. Works with tree-based models (XGBoost, LightGBM, Random Forest), deep learning (TensorFlow, PyTorch), linear models, and any black-box model",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "statistics",
+        "shap",
+        "modeling"
+      ]
+    },
+    {
+      "id": "analysis-stats/statistical-analysis",
+      "name": "statistical-analysis",
+      "domain": "analysis-stats",
+      "path": ".cursor/skills/analysis-stats/statistical-analysis/SKILL.md",
+      "description": "Guided statistical analysis with test selection and reporting. Use when you need help choosing appropriate tests for your data, assumption checking, power analysis, and APA-formatted results. Best for academic research reporting, test selection guidance. For implementing specific models programmatically use statsmodels.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "statistics",
+        "shap",
+        "modeling",
+        "statistical-analysis"
+      ]
+    },
+    {
+      "id": "analysis-stats/statsmodels",
+      "name": "statsmodels",
+      "domain": "analysis-stats",
+      "path": ".cursor/skills/analysis-stats/statsmodels/SKILL.md",
+      "description": "Statistical models library for Python. Use when you need specific model classes (OLS, GLM, mixed models, ARIMA) with detailed diagnostics, residuals, and inference. Best for econometrics, time series, rigorous inference with coefficient tables. For guided statistical test selection with APA reporting use statistical-analysis.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "statistics",
+        "shap",
+        "modeling",
+        "statsmodels"
+      ]
+    },
+    {
+      "id": "architecture/system-mapping",
+      "name": "system-mapping",
+      "domain": "architecture",
+      "path": ".cursor/skills/architecture/system-mapping/SKILL.md",
+      "description": "Map systems with diagrams—components, data flows, feedback loops, and causal relationships. Use for architecture understanding or stakeholder communication. Triggers: \"system map\", \"architecture diagram\", \"data flow\", \"C4\", \"how does this fit together\".",
+      "triggers": [
+        "system map",
+        "architecture diagram",
+        "data flow",
+        "C4",
+        "how does this fit together"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "architecture",
+        "diagrams",
+        "system-mapping"
+      ]
+    },
+    {
+      "id": "core-workflow/api-and-interface-design",
+      "name": "api-and-interface-design",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/api-and-interface-design/SKILL.md",
+      "description": "Design API and module boundaries with clear contracts, error semantics, pagination, and additive compatibility. Use before implementing REST/GraphQL endpoints, SDKs, or public module APIs. Triggers: \"API design\", \"interface contract\", \"endpoint design\", \"pagination\", \"error codes\", \"backward compatible\".",
+      "triggers": [
+        "API design",
+        "interface contract",
+        "endpoint design",
+        "pagination",
+        "error codes",
+        "backward compatible"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "api-and-interface-design"
+      ]
+    },
+    {
+      "id": "core-workflow/architecture-decision-records",
+      "name": "architecture-decision-records",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/architecture-decision-records/SKILL.md",
+      "description": ">   Create and maintain Architecture Decision Records (ADRs) for significant technical   choices—frameworks, data stores, API shapes, ML platform decisions. Use when   documenting a decision, onboarding, or superseding a prior approach.   Triggers: \"ADR\", \"architecture decision\", \"document decision\", \"why we chose\".",
+      "triggers": [
+        "ADR",
+        "architecture decision",
+        "document decision",
+        "why we chose"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "architecture-decision-records"
+      ]
+    },
+    {
+      "id": "core-workflow/clarify-underspecified",
+      "name": "clarify-underspecified",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/clarify-underspecified/SKILL.md",
+      "description": ">   Ask the minimum clarifying questions before implementing when scope, constraints,   or success criteria are unclear. Use when a request has multiple plausible   interpretations, missing acceptance criteria, or ambiguous environment constraints.   Triggers: \"unclear\", \"ambiguous\", \"not sure what you want\", \"multiple options\".",
+      "triggers": [
+        "unclear",
+        "ambiguous",
+        "not sure what you want",
+        "multiple options"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "clarify-underspecified"
+      ]
+    },
+    {
+      "id": "core-workflow/code-simplification",
+      "name": "code-simplification",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/code-simplification/SKILL.md",
+      "description": "Simplify working code while preserving behavior—remove dead paths, flatten nesting, clarify names, reduce duplication. Use after features work but code feels over-engineered. Triggers: \"simplify\", \"clean up\", \"too complex\", \"YAGNI\", \"reduce complexity\".",
+      "triggers": [
+        "simplify",
+        "clean up",
+        "too complex",
+        "YAGNI",
+        "reduce complexity"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "code-simplification"
+      ]
+    },
+    {
+      "id": "core-workflow/deprecation-and-migration",
+      "name": "deprecation-and-migration",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/deprecation-and-migration/SKILL.md",
+      "description": ">   Plan deprecation and migration—replacement first, consumer migration, strangler   and adapter patterns, zombie code removal. Use when sunsetting APIs, libraries,   or legacy modules.   Triggers: \"deprecate\", \"migration plan\", \"sunset\", \"remove legacy\", \"strangler\".",
+      "triggers": [
+        "deprecate",
+        "migration plan",
+        "sunset",
+        "remove legacy",
+        "strangler"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "deprecation-and-migration"
+      ]
+    },
+    {
+      "id": "core-workflow/design-smell-review",
+      "name": "design-smell-review",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/design-smell-review/SKILL.md",
+      "description": ">   Lightweight design smell review for modules and APIs—coupling, cohesion,   naming, boundaries, and unnecessary complexity. Use before large refactors or   when code feels hard to change. Complements gstack/review (diff-focused).   Triggers: \"design review\", \"code smell\", \"too complex\", \"refactor structure\".",
+      "triggers": [
+        "design review",
+        "code smell",
+        "too complex",
+        "refactor structure"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "design-smell-review"
+      ]
+    },
+    {
+      "id": "core-workflow/doubt-driven-review",
+      "name": "doubt-driven-review",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/doubt-driven-review/SKILL.md",
+      "description": ">   Adversarial fresh-context review for non-trivial decisions before they stand.   Use for production-impacting logic, security-sensitive changes, unfamiliar code,   or high-blast-radius architecture choices.   Triggers: \"doubt check\", \"adversarial review\", \"challenge this decision\", \"second look\".",
+      "triggers": [
+        "doubt check",
+        "adversarial review",
+        "challenge this decision",
+        "second look"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "doubt-driven-review"
+      ]
+    },
+    {
+      "id": "core-workflow/github-comment-triage",
+      "name": "github-comment-triage",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/github-comment-triage/SKILL.md",
+      "description": ">   Triage and address GitHub PR review comments systematically—classify, respond,   fix or defer with rationale. Use when a PR has review feedback, requested changes,   or unresolved threads.   Triggers: \"PR comments\", \"review feedback\", \"address comments\", \"requested changes\".",
+      "triggers": [
+        "PR comments",
+        "review feedback",
+        "address comments",
+        "requested changes"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "github-comment-triage"
+      ]
+    },
+    {
+      "id": "core-workflow/idea-refine",
+      "name": "idea-refine",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/idea-refine/SKILL.md",
+      "description": "Shape early ideas through divergent exploration and convergent narrowing before specs or builds. Use when brainstorming product features, model approaches, or architecture directions. Triggers: \"refine this idea\", \"brainstorm\", \"explore options\", \"which direction\", \"not sure yet\".",
+      "triggers": [
+        "refine this idea",
+        "brainstorm",
+        "explore options",
+        "which direction",
+        "not sure yet"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "idea-refine"
+      ]
+    },
+    {
+      "id": "core-workflow/incremental-implementation",
+      "name": "incremental-implementation",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/incremental-implementation/SKILL.md",
+      "description": ">   Implement multi-file changes in thin vertical slices—implement, test, verify,   commit. Use when a feature touches more than one file or feels too large for one pass.   Triggers: \"incremental\", \"vertical slice\", \"one step at a time\", \"small commits\".",
+      "triggers": [
+        "incremental",
+        "vertical slice",
+        "one step at a time",
+        "small commits"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "incremental-implementation"
+      ]
+    },
+    {
+      "id": "core-workflow/interview-me",
+      "name": "interview-me",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/interview-me/SKILL.md",
+      "description": "Extract user intent through structured one-question-at-a-time interviews before specs or implementation. Use when requirements are fuzzy, the user says \"help me think through\", or you need success criteria before planning. Triggers: \"interview me\", \"ask me questions\", \"clarify intent\", \"what do you need to know\".",
+      "triggers": [
+        "interview me",
+        "ask me questions",
+        "clarify intent",
+        "what do you need to know"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "interview-me"
+      ]
+    },
+    {
+      "id": "core-workflow/planning-and-task-breakdown",
+      "name": "planning-and-task-breakdown",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/planning-and-task-breakdown/SKILL.md",
+      "description": ">   Decompose specs into small, ordered tasks with acceptance criteria and verification   steps. Use when you have requirements and need an implementable plan or task list.   Triggers: \"break down tasks\", \"implementation plan\", \"task breakdown\", \"plan mode\".",
+      "triggers": [
+        "break down tasks",
+        "implementation plan",
+        "task breakdown",
+        "plan mode"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "planning-and-task-breakdown"
+      ]
+    },
+    {
+      "id": "core-workflow/receiving-code-review",
+      "name": "receiving-code-review",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/receiving-code-review/SKILL.md",
+      "description": ">   Receive code review feedback constructively—verify claims, prioritize fixes,   push back with evidence when needed. Use when acting on reviewer comments or   preparing a second review round.   Triggers: \"code review\", \"reviewer said\", \"address review\", \"feedback on PR\".",
+      "triggers": [
+        "code review",
+        "reviewer said",
+        "address review",
+        "feedback on PR"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "receiving-code-review"
+      ]
+    },
+    {
+      "id": "core-workflow/source-driven-development",
+      "name": "source-driven-development",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/source-driven-development/SKILL.md",
+      "description": ">   Ground framework and library decisions in official documentation—detect versions,   fetch relevant docs, cite sources, flag unverified patterns. Use when API correctness   matters for React, Next.js, Python libs, cloud SDKs, or unfamiliar stacks.   Triggers: \"official docs\", \"verify API\", \"source-driven\", \"is this API still valid\".",
+      "triggers": [
+        "official docs",
+        "verify API",
+        "source-driven",
+        "is this API still valid"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "source-driven-development"
+      ]
+    },
+    {
+      "id": "core-workflow/spec-driven-development",
+      "name": "spec-driven-development",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/spec-driven-development/SKILL.md",
+      "description": ">   Write a structured spec before significant implementation—objective, commands,   boundaries, testing, and success criteria. Use when starting a feature, project,   or multi-file change without a written spec.   Triggers: \"write spec\", \"PRD\", \"requirements\", \"spec before code\", \"what are we building\".",
+      "triggers": [
+        "write spec",
+        "PRD",
+        "requirements",
+        "spec before code",
+        "what are we building"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "spec-driven-development"
+      ]
+    },
+    {
+      "id": "core-workflow/test-failure-triage",
+      "name": "test-failure-triage",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/test-failure-triage/SKILL.md",
+      "description": ">   Systematically triage failing tests by grouping errors, fixing root causes in   priority order, and verifying incrementally. Use when CI fails, test suite is   broken, or multiple tests fail after a refactor or merge.   Triggers: \"tests failing\", \"fix tests\", \"CI red\", \"make tests pass\".",
+      "triggers": [
+        "tests failing",
+        "fix tests",
+        "CI red",
+        "make tests pass"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "test-failure-triage"
+      ]
+    },
+    {
+      "id": "core-workflow/test-first-development",
+      "name": "test-first-development",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/test-first-development/SKILL.md",
+      "description": ">   Apply test-first discipline for behavior changes and bugfixes: define expected   behavior, add or run a failing test, then implement minimally. Use when fixing   bugs, changing logic, or adding features that need regression protection.   Triggers: \"bugfix\", \"TDD\", \"regression test\", \"behavior change\", \"add test\".",
+      "triggers": [
+        "bugfix",
+        "TDD",
+        "regression test",
+        "behavior change",
+        "add test"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "test-first-development"
+      ]
+    },
+    {
+      "id": "core-workflow/verify-before-done",
+      "name": "verify-before-done",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/verify-before-done/SKILL.md",
+      "description": ">   Require fresh verification evidence before claiming tests pass, builds succeed,   or work is complete. Use when finishing a task, creating a PR, or reporting status.   Triggers: \"done\", \"fixed\", \"passes\", \"ready to merge\", \"all tests green\".",
+      "triggers": [
+        "done",
+        "fixed",
+        "passes",
+        "ready to merge",
+        "all tests green"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "verify-before-done"
+      ]
+    },
+    {
+      "id": "core-workflow/work-access-handoff",
+      "name": "work-access-handoff",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/work-access-handoff/SKILL.md",
+      "description": "Explain and document work access layers—repo permissions, local vs cloud environments, handoff packages for collaborators. Triggers: \"handoff\", \"access\", \"onboard collaborator\", \"share project\", \"where is the work\".",
+      "triggers": [
+        "handoff",
+        "access",
+        "onboard collaborator",
+        "share project",
+        "where is the work"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "work-access-handoff"
+      ]
+    },
+    {
+      "id": "data-compute/dask",
+      "name": "dask",
+      "domain": "data-compute",
+      "path": ".cursor/skills/data-compute/dask/SKILL.md",
+      "description": "Distributed computing for larger-than-RAM pandas/NumPy workflows. Use when you need to scale existing pandas/NumPy code beyond memory or across clusters. Best for parallel file processing, distributed ML, integration with existing pandas code. For out-of-core analytics on single machine use vaex; for in-memory speed use polars.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "data",
+        "etl",
+        "compute",
+        "dask"
+      ]
+    },
+    {
+      "id": "data-compute/networkx",
+      "name": "networkx",
+      "domain": "data-compute",
+      "path": ".cursor/skills/data-compute/networkx/SKILL.md",
+      "description": "Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths, centrality, clustering), detecting communities, generating synthetic networks, or visualizing network topologies. Applicable to social networks, biological networks, transportation systems, citation networks, and any domain involving pairwise relationships.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "data",
+        "etl",
+        "compute",
+        "networkx"
+      ]
+    },
+    {
+      "id": "data-compute/polars",
+      "name": "polars",
+      "domain": "data-compute",
+      "path": ".cursor/skills/data-compute/polars/SKILL.md",
+      "description": "Fast in-memory DataFrame library for datasets that fit in RAM. Use when pandas is too slow but data still fits in memory. Lazy evaluation, parallel execution, Apache Arrow backend. Best for 1-100GB datasets, ETL pipelines, faster pandas replacement. For larger-than-RAM data use dask or vaex.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "data",
+        "etl",
+        "compute",
+        "polars"
+      ]
+    },
+    {
+      "id": "eda-research/exploratory-data-analysis",
+      "name": "exploratory-data-analysis",
+      "domain": "eda-research",
+      "path": ".cursor/skills/eda-research/exploratory-data-analysis/SKILL.md",
+      "description": "Perform comprehensive exploratory data analysis on scientific data files across 200+ file formats. This skill should be used when analyzing any scientific data file to understand its structure, content, quality, and characteristics. Automatically detects file type and generates detailed markdown reports with format-specific analysis, quality metrics, and downstream analysis recommendations. Covers chemistry, bioinformatics, microscopy, spectroscopy, proteomics, metabolomics, and general scientif",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "eda",
+        "research",
+        "exploratory-data-analysis"
+      ]
+    },
+    {
+      "id": "eda-research/hypothesis-generation",
+      "name": "hypothesis-generation",
+      "domain": "eda-research",
+      "path": ".cursor/skills/eda-research/hypothesis-generation/SKILL.md",
+      "description": "Structured hypothesis formulation from observations. Use when you have experimental observations or data and need to formulate testable hypotheses with predictions, propose mechanisms, and design experiments to test them. Follows scientific method framework. For open-ended ideation use scientific-brainstorming; for automated LLM-driven hypothesis testing on datasets use hypogenic.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "eda",
+        "research",
+        "hypothesis-generation"
+      ]
+    },
+    {
+      "id": "eda-research/umap-learn",
+      "name": "umap-learn",
+      "domain": "eda-research",
+      "path": ".cursor/skills/eda-research/umap-learn/SKILL.md",
+      "description": "UMAP dimensionality reduction. Fast nonlinear manifold learning for 2D/3D visualization, clustering preprocessing (HDBSCAN), supervised/parametric UMAP, for high-dimensional data.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "eda",
+        "research",
+        "umap-learn"
+      ]
+    },
+    {
+      "id": "frontend-engineering/browser-testing-with-devtools",
+      "name": "browser-testing-with-devtools",
+      "domain": "frontend-engineering",
+      "path": ".cursor/skills/frontend-engineering/browser-testing-with-devtools/SKILL.md",
+      "description": "Verify web apps with browser DevTools—DOM, console, network, performance, and accessibility at runtime. Use with Chrome DevTools MCP or headless browser tools. Triggers: \"DevTools\", \"browser test\", \"console errors\", \"network tab\", \"Lighthouse\", \"runtime check\".",
+      "triggers": [
+        "DevTools",
+        "browser test",
+        "console errors",
+        "network tab",
+        "Lighthouse",
+        "runtime check"
+      ],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "frontend",
+        "ui",
+        "browser",
+        "browser-testing-with-devtools"
+      ]
+    },
+    {
+      "id": "frontend-engineering/frontend-ui-accessibility",
+      "name": "frontend-ui-accessibility",
+      "domain": "frontend-engineering",
+      "path": ".cursor/skills/frontend-engineering/frontend-ui-accessibility/SKILL.md",
+      "description": ">   Build accessible UI—semantic HTML, keyboard support, ARIA when needed, WCAG-oriented   checks. Use when implementing or reviewing web UI, forms, modals, and design systems.   Triggers: \"accessibility\", \"a11y\", \"WCAG\", \"keyboard nav\", \"screen reader\".",
+      "triggers": [
+        "accessibility",
+        "a11y",
+        "WCAG",
+        "keyboard nav",
+        "screen reader"
+      ],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "frontend",
+        "ui",
+        "browser",
+        "frontend-ui-accessibility"
+      ]
+    },
+    {
+      "id": "frontend-engineering/frontend-ui-engineering",
+      "name": "frontend-ui-engineering",
+      "domain": "frontend-engineering",
+      "path": ".cursor/skills/frontend-engineering/frontend-ui-engineering/SKILL.md",
+      "description": "Build and refine web UI—component structure, responsive layout, design tokens, state, and accessibility. Use for feature UI work beyond WCAG checks alone. Triggers: \"build UI\", \"component\", \"responsive\", \"design system\", \"frontend\", \"layout\".",
+      "triggers": [
+        "build UI",
+        "component",
+        "responsive",
+        "design system",
+        "frontend",
+        "layout"
+      ],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "frontend",
+        "ui",
+        "browser",
+        "frontend-ui-engineering"
+      ]
+    },
+    {
+      "id": "gstack",
+      "name": "gstack",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/SKILL.md",
+      "description": "Fast headless browser for QA testing and site dogfooding. Navigate pages,   interact with elements, verify state, diff before/after, take annotated screenshots,   test responsive layouts, forms, uploads, dialogs, and capture bug evidence. Use   when asked to open or test a site, verify a deployment, dogfood a user flow, or   file a bug with screenshots. (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack"
+      ]
+    },
+    {
+      "id": "gstack/browser-qa/benchmark",
+      "name": "benchmark",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/browser-qa/benchmark/SKILL.md",
+      "description": "Performance regression detection using the browse daemon. Establishes   baselines for page load times, Core Web Vitals, and resource sizes. Compares before/after   on every PR. Tracks performance trends over time. Use when: \"performance\", \"benchmark\",   \"page speed\", \"lighthouse\", \"web vitals\", \"bundle size\", \"load time\". (gstack) Voice   triggers (speech-to-text aliases): \"speed test\", \"check performance\".",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "benchmark"
+      ]
+    },
+    {
+      "id": "gstack/browser-qa/benchmark-models",
+      "name": "benchmark-models",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/browser-qa/benchmark-models/SKILL.md",
+      "description": "Cross-model benchmark for gstack skills. Runs the same prompt through   Claude, GPT (via Codex CLI), and Gemini side-by-side — compares latency, tokens,   cost, and optionally quality via LLM judge. Answers \"which model is actually best   for this skill?\" with data instead of vibes. Separate from /benchmark, which measures   web page performance. Use when: \"benchmark models\", \"compare models\", \"which model   is best for X\", \"cross-model comparison\", \"model shootout\". (gstack) Voice triggers   (s",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "benchmark-models"
+      ]
+    },
+    {
+      "id": "gstack/browser-qa/browse",
+      "name": "browse",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/browser-qa/browse/SKILL.md",
+      "description": "Fast headless browser for QA testing and site dogfooding. Navigate any   URL, interact with elements, verify page state, diff before/after actions, take   annotated screenshots, check responsive layouts, test forms and uploads, handle   dialogs, and assert element states. ~100ms per command. Use when you need to test   a feature, verify a deployment, dogfood a user flow, or file a bug with evidence.   Use when asked to \"open in browser\", \"test the site\", \"take a screenshot\", or \"dogfood   this\".",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "browse"
+      ]
+    },
+    {
+      "id": "gstack/browser-qa/canary",
+      "name": "canary",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/browser-qa/canary/SKILL.md",
+      "description": "Post-deploy canary monitoring. Watches the live app for console errors,   performance regressions, and page failures using the browse daemon. Takes periodic   screenshots, compares against pre-deploy baselines, and alerts on anomalies. Use   when: \"monitor deploy\", \"canary\", \"post-deploy check\", \"watch production\", \"verify   deploy\". (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "canary"
+      ]
+    },
+    {
+      "id": "gstack/browser-qa/qa",
+      "name": "qa",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/browser-qa/qa/SKILL.md",
+      "description": "Systematically QA test a web application and fix bugs found. Runs QA   testing, then iteratively fixes bugs in source code, committing each fix atomically   and re-verifying. Use when asked to \"qa\", \"QA\", \"test this site\", \"find bugs\", \"test   and fix\", or \"fix what''s broken\". Proactively suggest when the user says a feature   is ready for testing or asks \"does this work?\". Three tiers: Quick (critical/high   only), Standard (+ medium), Exhaustive (+ cosmetic). Produces before/after health   sc",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack"
+      ]
+    },
+    {
+      "id": "gstack/browser-qa/qa-only",
+      "name": "qa-only",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/browser-qa/qa-only/SKILL.md",
+      "description": "Report-only QA testing. Systematically tests a web application and produces   a structured report with health score, screenshots, and repro steps — but never   fixes anything. Use when asked to \"just report bugs\", \"qa report only\", or \"test   but don''t fix\". For the full test-fix-verify loop, use /qa instead. Proactively   suggest when the user wants a bug report without any code changes. (gstack) Voice   triggers (speech-to-text aliases): \"bug report\", \"just check for bugs\".",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "qa-only"
+      ]
+    },
+    {
+      "id": "gstack/code-quality/codex",
+      "name": "codex",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/code-quality/codex/SKILL.md",
+      "description": "OpenAI Codex CLI wrapper — three modes. Code review: independent diff   review via codex review with pass/fail gate. Challenge: adversarial mode that tries   to break your code. Consult: ask codex anything with session continuity for follow-ups.   The \"200 IQ autistic developer\" second opinion. Use when asked to \"codex review\",   \"codex challenge\", \"ask codex\", \"second opinion\", or \"consult codex\". (gstack) Voice   triggers (speech-to-text aliases): \"code x\", \"code ex\", \"get another opinion\".",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "codex"
+      ]
+    },
+    {
+      "id": "gstack/code-quality/health",
+      "name": "health",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/code-quality/health/SKILL.md",
+      "description": "Code quality dashboard. Wraps existing project tools (type checker,   linter, test runner, dead code detector, shell linter), computes a weighted composite   0-10 score, and tracks trends over time. Use when: \"health check\", \"code quality\",   \"how healthy is the codebase\", \"run all checks\", \"quality score\". (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "health"
+      ]
+    },
+    {
+      "id": "gstack/code-quality/investigate",
+      "name": "investigate",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/code-quality/investigate/SKILL.md",
+      "description": "Systematic debugging with root cause investigation. Four phases: investigate,   analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when   asked to \"debug this\", \"fix this bug\", \"why is this broken\", \"investigate this error\",   or \"root cause analysis\". Proactively invoke this skill (do NOT debug directly)   when the user reports errors, 500 errors, stack traces, unexpected behavior, \"it   was working yesterday\", or is troubleshooting why something stopped working. (gstac",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "investigate"
+      ]
+    },
+    {
+      "id": "gstack/code-quality/review",
+      "name": "review",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/code-quality/review/SKILL.md",
+      "description": "Pre-landing PR review. Analyzes diff against the base branch for SQL   safety, LLM trust boundary violations, conditional side effects, and other structural   issues. Use when asked to \"review this PR\", \"code review\", \"pre-landing review\",   or \"check my diff\". Proactively suggest when the user is about to merge or land   code changes. (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "review"
+      ]
+    },
+    {
+      "id": "gstack/context-memory/context-restore",
+      "name": "context-restore",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/context-memory/context-restore/SKILL.md",
+      "description": "Restore working context saved earlier by /context-save. Loads the most   recent saved state (across all branches by default) so you can pick up where you   left off — even across Conductor workspace handoffs. Use when asked to \"resume\",   \"restore context\", \"where was I\", or \"pick up where I left off\". Pair with /context-save.   Formerly /checkpoint resume — renamed because Claude Code treats /checkpoint as   a native rewind alias in current environments. (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "context-restore"
+      ]
+    },
+    {
+      "id": "gstack/context-memory/context-save",
+      "name": "context-save",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/context-memory/context-save/SKILL.md",
+      "description": "Save working context. Captures git state, decisions made, and remaining   work so any future session can pick up without losing a beat. Use when asked to   \"save progress\", \"save state\", \"context save\", or \"save my work\". Pair with /context-restore   to resume later. Formerly /checkpoint — renamed because Claude Code treats /checkpoint   as a native rewind alias in current environments, which was shadowing this skill.   (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "context-save"
+      ]
+    },
+    {
+      "id": "gstack/context-memory/learn",
+      "name": "learn",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/context-memory/learn/SKILL.md",
+      "description": "Manage project learnings. Review, search, prune, and export what gstack   has learned across sessions. Use when asked to \"what have we learned\", \"show learnings\",   \"prune stale learnings\", or \"export learnings\". Proactively suggest when the user   asks about past patterns or wonders \"didn't we fix this before?",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "learn"
+      ]
+    },
+    {
+      "id": "gstack/context-memory/setup-gbrain",
+      "name": "setup-gbrain",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/context-memory/setup-gbrain/SKILL.md",
+      "description": "Set up gbrain for this coding agent: install the CLI, initialize a local   PGLite or Supabase brain, register MCP, capture per-remote trust policy. One command   from zero to \"gbrain is running, and this agent can call it.\" Use when: \"setup gbrain\",   \"connect gbrain\", \"start gbrain\", \"install gbrain\", \"configure gbrain for this machine\".   (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "setup-gbrain"
+      ]
+    },
+    {
+      "id": "gstack/context-memory/sync-gbrain",
+      "name": "sync-gbrain",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/context-memory/sync-gbrain/SKILL.md",
+      "description": "Keep gbrain current with this repo''s code and refresh agent search   guidance in CLAUDE.md. Wraps the gstack-gbrain-sync orchestrator with state probing,   native code-surface registration, capability checks, and a verdict block. Re-runnable,   idempotent. Use when: \"sync gbrain\", \"refresh gbrain\", \"re-index this repo\", \"gbrain   search isn''t finding things\". (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "sync-gbrain"
+      ]
+    },
+    {
+      "id": "gstack/deploy-ship/document-release",
+      "name": "document-release",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/deploy-ship/document-release/SKILL.md",
+      "description": "Post-ship documentation update. Reads all project docs, cross-references   the diff, updates README/ARCHITECTURE/CONTRIBUTING/CLAUDE.md to match what shipped,   polishes CHANGELOG voice, cleans up TODOS, and optionally bumps VERSION. Use when   asked to \"update the docs\", \"sync documentation\", or \"post-ship docs\". Proactively   suggest after a PR is merged or code is shipped. (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "document-release"
+      ]
+    },
+    {
+      "id": "gstack/deploy-ship/land-and-deploy",
+      "name": "land-and-deploy",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/deploy-ship/land-and-deploy/SKILL.md",
+      "description": "Land and deploy workflow. Merges the PR, waits for CI and deploy, verifies   production health via canary checks. Takes over after /ship creates the PR. Use   when: \"merge\", \"land\", \"deploy\", \"merge and verify\", \"land it\", \"ship it to production\".   (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "land-and-deploy"
+      ]
+    },
+    {
+      "id": "gstack/deploy-ship/landing-report",
+      "name": "landing-report",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/deploy-ship/landing-report/SKILL.md",
+      "description": "Read-only queue dashboard for workspace-aware ship. Shows which VERSION   slots are currently claimed by open PRs, which sibling Conductor workspaces have   WIP work likely to ship soon, and what slot /ship would pick next. No mutations   — just a snapshot. Use when asked to \"landing report\", \"what's in the queue\", \"show   me open PRs\", or \"which version do I claim next\". (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "landing-report"
+      ]
+    },
+    {
+      "id": "gstack/deploy-ship/setup-deploy",
+      "name": "setup-deploy",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/deploy-ship/setup-deploy/SKILL.md",
+      "description": "Configure deployment settings for /land-and-deploy. Detects your deploy   platform (Fly.io, Render, Vercel, Netlify, Heroku, GitHub Actions, custom), production   URL, health check endpoints, and deploy status commands. Writes the configuration   to CLAUDE.md so all future deploys are automatic. Use when: \"setup deploy\", \"configure   deployment\", \"set up land-and-deploy\", \"how do I deploy with gstack\", \"add deploy   config\".",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "setup-deploy"
+      ]
+    },
+    {
+      "id": "gstack/deploy-ship/ship",
+      "name": "ship",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/deploy-ship/ship/SKILL.md",
+      "description": "Ship workflow: detect + merge base branch, run tests, review diff, bump   VERSION, update CHANGELOG, commit, push, create PR. Use when asked to \"ship\", \"deploy\",   \"push to main\", \"create a PR\", \"merge and push\", or \"get it deployed\". Proactively   invoke this skill (do NOT push/PR directly) when the user says code is ready, asks   about deploying, wants to push code up, or asks to create a PR. (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack"
+      ]
+    },
+    {
+      "id": "gstack/design/design-consultation",
+      "name": "design-consultation",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/design/design-consultation/SKILL.md",
+      "description": "Design consultation: understands your product, researches the landscape,   proposes a complete design system (aesthetic, typography, color, layout, spacing,   motion), and generates font+color preview pages. Creates DESIGN.md as your project''s   design source of truth. For existing sites, use /plan-design-review to infer the   system instead. Use when asked to \"design system\", \"brand guidelines\", or \"create   DESIGN.md\". Proactively suggest when starting a new project''s UI with no existing   d",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "design-consultation"
+      ]
+    },
+    {
+      "id": "gstack/design/design-html",
+      "name": "design-html",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/design/design-html/SKILL.md",
+      "description": "Design finalization: generates production-quality Pretext-native HTML/CSS.   Works with approved mockups from /design-shotgun, CEO plans from /plan-ceo-review,   design review context from /plan-design-review, or from scratch with a user description.   Text actually reflows, heights are computed, layouts are dynamic. 30KB overhead,   zero deps. Smart API routing: picks the right Pretext patterns for each design type.   Use when: \"finalize this design\", \"turn this into HTML\", \"build me a page\", \"",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "design-html"
+      ]
+    },
+    {
+      "id": "gstack/design/design-review",
+      "name": "design-review",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/design/design-review/SKILL.md",
+      "description": "Designer''s eye QA: finds visual inconsistency, spacing issues, hierarchy   problems, AI slop patterns, and slow interactions — then fixes them. Iteratively   fixes issues in source code, committing each fix atomically and re-verifying with   before/after screenshots. For plan-mode design review (before implementation), use   /plan-design-review. Use when asked to \"audit the design\", \"visual QA\", \"check if   it looks good\", or \"design polish\". Proactively suggest when the user mentions visual   ",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "design-review"
+      ]
+    },
+    {
+      "id": "gstack/design/design-shotgun",
+      "name": "design-shotgun",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/design/design-shotgun/SKILL.md",
+      "description": "Design shotgun: generate multiple AI design variants, open a comparison   board, collect structured feedback, and iterate. Standalone design exploration you   can run anytime. Use when: \"explore designs\", \"show me options\", \"design variants\",   \"visual brainstorm\", or \"I don''t like how this looks\". Proactively suggest when   the user describes a UI feature but hasn''t seen what it could look like. (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "design-shotgun"
+      ]
+    },
+    {
+      "id": "gstack/plan-review/autoplan",
+      "name": "autoplan",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/plan-review/autoplan/SKILL.md",
+      "description": "Auto-review pipeline — reads the full CEO, design, eng, and DX review   skills from disk and runs them sequentially with auto-decisions using 6 decision   principles. Surfaces taste decisions (close approaches, borderline scope, codex   disagreements) at a final approval gate. One command, fully reviewed plan out. Use   when asked to \"auto review\", \"autoplan\", \"run all reviews\", \"review this plan automatically\",   or \"make the decisions for me\". Proactively suggest when the user has a plan file ",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "autoplan"
+      ]
+    },
+    {
+      "id": "gstack/plan-review/devex-review",
+      "name": "devex-review",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/plan-review/devex-review/SKILL.md",
+      "description": "Live developer experience audit. Uses the browse tool to actually TEST   the developer experience: navigates docs, tries the getting started flow, times   TTHW, screenshots error messages, evaluates CLI help text. Produces a DX scorecard   with evidence. Compares against /plan-devex-review scores if they exist (the boomerang:   plan said 3 minutes, reality says 8). Use when asked to \"test the DX\", \"DX audit\",   \"developer experience test\", or \"try the onboarding\". Proactively suggest after   shi",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "devex-review"
+      ]
+    },
+    {
+      "id": "gstack/plan-review/plan-ceo-review",
+      "name": "plan-ceo-review",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/plan-review/plan-ceo-review/SKILL.md",
+      "description": "CEO/founder-mode plan review. Rethink the problem, find the 10-star   product, challenge premises, expand scope when it creates a better product. Four   modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick   expansions), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials).   Use when asked to \"think bigger\", \"expand scope\", \"strategy review\", \"rethink this\",   or \"is this ambitious enough\". Proactively suggest when the user is questioning   scope or amb",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "plan-ceo-review"
+      ]
+    },
+    {
+      "id": "gstack/plan-review/plan-design-review",
+      "name": "plan-design-review",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/plan-review/plan-design-review/SKILL.md",
+      "description": "Designer's eye plan review — interactive, like CEO and Eng review. Rates   each design dimension 0-10, explains what would make it a 10, then fixes the plan   to get there. Works in plan mode. For live site visual audits, use /design-review.   Use when asked to \"review the design plan\" or \"design critique\". Proactively suggest   when the user has a plan with UI/UX components that should be reviewed before implementation.   (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "plan-design-review"
+      ]
+    },
+    {
+      "id": "gstack/plan-review/plan-devex-review",
+      "name": "plan-devex-review",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/plan-review/plan-devex-review/SKILL.md",
+      "description": "Interactive developer experience plan review. Explores developer personas,   benchmarks against competitors, designs magical moments, and traces friction points   before scoring. Three modes: DX EXPANSION (competitive advantage), DX POLISH (bulletproof   every touchpoint), DX TRIAGE (critical gaps only). Use when asked to \"DX review\",   \"developer experience audit\", \"devex review\", or \"API design review\". Proactively   suggest when the user has a plan for developer-facing products (APIs, CLIs, S",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "plan-devex-review"
+      ]
+    },
+    {
+      "id": "gstack/plan-review/plan-eng-review",
+      "name": "plan-eng-review",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/plan-review/plan-eng-review/SKILL.md",
+      "description": "Eng manager-mode plan review. Lock in the execution plan — architecture,   data flow, diagrams, edge cases, test coverage, performance. Walks through issues   interactively with opinionated recommendations. Use when asked to \"review the architecture\",   \"engineering review\", or \"lock in the plan\". Proactively suggest when the user has   a plan or design doc and is about to start coding — to catch architecture issues   before implementation. (gstack) Voice triggers (speech-to-text aliases): \"tech",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "plan-eng-review"
+      ]
+    },
+    {
+      "id": "gstack/plan-review/plan-tune",
+      "name": "plan-tune",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/plan-review/plan-tune/SKILL.md",
+      "description": "Self-tuning question sensitivity + developer psychographic for gstack   (v1: observational). Review which AskUserQuestion prompts fire across gstack skills,   set per-question preferences (never-ask / always-ask / ask-only-for-one-way), inspect   the dual-track profile (what you declared vs what your behavior suggests), and enable/disable   question tuning. Conversational interface — no CLI syntax required. Use when asked   to \"tune questions\", \"stop asking me that\", \"too many questions\", \"show ",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "plan-tune"
+      ]
+    },
+    {
+      "id": "gstack/remote-agents/openclaw/gstack-openclaw-ceo-review",
+      "name": "gstack-openclaw-ceo-review",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/remote-agents/openclaw/gstack-openclaw-ceo-review/SKILL.md",
+      "description": "Use when asked to review a plan, challenge a proposal, run a CEO review,   poke holes in an approach, think bigger about scope, or decide whether to expand   or reduce the plan.",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "gstack-openclaw-ceo-review"
+      ]
+    },
+    {
+      "id": "gstack/remote-agents/openclaw/gstack-openclaw-investigate",
+      "name": "gstack-openclaw-investigate",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/remote-agents/openclaw/gstack-openclaw-investigate/SKILL.md",
+      "description": "Use when asked to debug, fix a bug, investigate an error, or do root   cause analysis, and when users report errors, stack traces, unexpected behavior,   or say something stopped working.",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "gstack-openclaw-investigate"
+      ]
+    },
+    {
+      "id": "gstack/remote-agents/openclaw/gstack-openclaw-office-hours",
+      "name": "gstack-openclaw-office-hours",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/remote-agents/openclaw/gstack-openclaw-office-hours/SKILL.md",
+      "description": "Use when asked to brainstorm, evaluate whether an idea is worth building,   run office hours, or think through a new product idea or design direction before   any code is written.",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "gstack-openclaw-office-hours"
+      ]
+    },
+    {
+      "id": "gstack/remote-agents/openclaw/gstack-openclaw-retro",
+      "name": "gstack-openclaw-retro",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/remote-agents/openclaw/gstack-openclaw-retro/SKILL.md",
+      "description": "Weekly engineering retrospective. Analyzes commit history, work patterns,   and code quality metrics with persistent history and trend tracking. Team-aware   with per-person contributions, praise, and growth areas. Use when asked for weekly   retro, what shipped this week, or engineering retrospective.",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "gstack-openclaw-retro"
+      ]
+    },
+    {
+      "id": "gstack/remote-agents/pair-agent",
+      "name": "pair-agent",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/remote-agents/pair-agent/SKILL.md",
+      "description": "Pair a remote AI agent with your browser. One command generates a setup   key and prints instructions the other agent can follow to connect. Works with OpenClaw,   Hermes, Codex, Cursor, or any agent that can make HTTP requests. The remote agent   gets its own tab with scoped access (read+write by default, admin on request). Use   when asked to \"pair agent\", \"connect agent\", \"share browser\", \"remote browser\",   \"let another agent use my browser\", or \"give browser access\". (gstack) Voice triggers",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "pair-agent"
+      ]
+    },
+    {
+      "id": "gstack/scrape/browser-skills/hackernews-frontpage",
+      "name": "hackernews-frontpage",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/scrape/browser-skills/hackernews-frontpage/SKILL.md",
+      "description": "Scrape the Hacker News front page (titles, points, comment counts).",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "hackernews-frontpage"
+      ]
+    },
+    {
+      "id": "gstack/scrape/scrape",
+      "name": "scrape",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/scrape/scrape/SKILL.md",
+      "description": "Pull data from a web page. First call on a new intent prototypes the   flow via $B primitives and returns JSON. Subsequent calls on a matching intent route   to a codified browser-skill and return in ~200ms. Read-only — for mutating flows   (form fills, clicks, submissions), use /automate. Use when asked to \"scrape\", \"get   data from\", \"pull\", \"extract from\", or \"what's on\" a page. (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "scrape"
+      ]
+    },
+    {
+      "id": "gstack/scrape/skillify",
+      "name": "skillify",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/scrape/skillify/SKILL.md",
+      "description": "Codify the most recent successful /scrape flow into a permanent browser-skill   on disk. Future /scrape calls with the same intent run the codified script in ~200ms   instead of re-driving the page. Walks back through the conversation, synthesizes   script.ts + script.test.ts + fixture, runs the test in a temp dir, and asks before   committing. Use when asked to \"skillify\", \"codify\", \"save this scrape\", or \"make   this permanent\". (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "skillify"
+      ]
+    },
+    {
+      "id": "gstack/security-safety/careful",
+      "name": "careful",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/security-safety/careful/SKILL.md",
+      "description": "Safety guardrails for destructive commands. Warns before rm -rf, DROP   TABLE, force-push, git reset --hard, kubectl delete, and similar destructive operations.   User can override each warning. Use when touching prod, debugging live systems,   or working in a shared environment. Use when asked to \"be careful\", \"safety mode\",   \"prod mode\", or \"careful mode\". (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "careful"
+      ]
+    },
+    {
+      "id": "gstack/security-safety/cso",
+      "name": "cso",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/security-safety/cso/SKILL.md",
+      "description": "Chief Security Officer mode. Infrastructure-first security audit: secrets   archaeology, dependency supply chain, CI/CD pipeline security, LLM/AI security,   skill supply chain scanning, plus OWASP Top 10, STRIDE threat modeling, and active   verification. Two modes: daily (zero-noise, 8/10 confidence gate) and comprehensive   (monthly deep scan, 2/10 bar). Trend tracking across audit runs. Use when: \"security   audit\", \"threat model\", \"pentest review\", \"OWASP\", \"CSO review\". (gstack) Voice   tr",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "cso"
+      ]
+    },
+    {
+      "id": "gstack/security-safety/freeze",
+      "name": "freeze",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/security-safety/freeze/SKILL.md",
+      "description": "Restrict file edits to a specific directory for the session. Blocks Edit   and Write outside the allowed path. Use when debugging to prevent accidentally \"fixing\"   unrelated code, or when you want to scope changes to one module. Use when asked   to \"freeze\", \"restrict edits\", \"only edit this folder\", or \"lock down edits\". (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "freeze"
+      ]
+    },
+    {
+      "id": "gstack/security-safety/guard",
+      "name": "guard",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/security-safety/guard/SKILL.md",
+      "description": "Full safety mode: destructive command warnings + directory-scoped edits.   Combines /careful (warns before rm -rf, DROP TABLE, force-push, etc.) with /freeze   (blocks edits outside a specified directory). Use for maximum safety when touching   prod or debugging live systems. Use when asked to \"guard mode\", \"full safety\", \"lock   it down\", or \"maximum safety\". (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "guard"
+      ]
+    },
+    {
+      "id": "gstack/security-safety/unfreeze",
+      "name": "unfreeze",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/security-safety/unfreeze/SKILL.md",
+      "description": "Clear the freeze boundary set by /freeze, allowing edits to all directories   again. Use when you want to widen edit scope without ending the session. Use when   asked to \"unfreeze\", \"unlock edits\", \"remove freeze\", or \"allow all edits\". (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "unfreeze"
+      ]
+    },
+    {
+      "id": "gstack/utility/gstack-upgrade",
+      "name": "gstack-upgrade",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/utility/gstack-upgrade/SKILL.md",
+      "description": "Upgrade gstack to the latest version. Detects global vs vendored install,   runs the upgrade, and shows what''s new. Use when asked to \"upgrade gstack\", \"update   gstack\", or \"get latest version\". Voice triggers (speech-to-text aliases): \"upgrade   the tools\", \"update the tools\", \"gee stack upgrade\", \"g stack upgrade\".",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "gstack-upgrade"
+      ]
+    },
+    {
+      "id": "gstack/utility/office-hours",
+      "name": "office-hours",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/utility/office-hours/SKILL.md",
+      "description": "YC Office Hours — two modes. Startup mode: six forcing questions that   expose demand reality, status quo, desperate specificity, narrowest wedge, observation,   and future-fit. Builder mode: design thinking brainstorming for side projects, hackathons,   learning, and open source. Saves a design doc. Use when asked to \"brainstorm this\",   \"I have an idea\", \"help me think through this\", \"office hours\", or \"is this worth   building\". Proactively invoke this skill (do NOT answer directly) when the ",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "office-hours"
+      ]
+    },
+    {
+      "id": "gstack/utility/open-gstack-browser",
+      "name": "open-gstack-browser",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/utility/open-gstack-browser/SKILL.md",
+      "description": "Launch GStack Browser — AI-controlled Chromium with the sidebar extension   baked in. Opens a visible browser window where you can watch every action in real   time. The sidebar shows a live activity feed and chat. Anti-bot stealth built in.   Use when asked to \"open gstack browser\", \"launch browser\", \"connect chrome\", \"open   chrome\", \"real browser\", \"launch chrome\", \"side panel\", or \"control my browser\".   Voice triggers (speech-to-text aliases): \"show me the browser\".",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "open-gstack-browser"
+      ]
+    },
+    {
+      "id": "gstack/utility/retro",
+      "name": "retro",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/utility/retro/SKILL.md",
+      "description": "Weekly engineering retrospective. Analyzes commit history, work patterns,   and code quality metrics with persistent history and trend tracking. Team-aware:   breaks down per-person contributions with praise and growth areas. Use when asked   to \"weekly retro\", \"what did we ship\", or \"engineering retrospective\". Proactively   suggest at the end of a work week or sprint. (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "retro"
+      ]
+    },
+    {
+      "id": "gstack/utility/setup-browser-cookies",
+      "name": "setup-browser-cookies",
+      "domain": "gstack",
+      "path": ".cursor/skills/gstack/utility/setup-browser-cookies/SKILL.md",
+      "description": "Import cookies from your real Chromium browser into the headless browse   session. Opens an interactive picker UI where you select which cookie domains to   import. Use before QA testing authenticated pages. Use when asked to \"import cookies\",   \"login to the site\", or \"authenticate the browser\". (gstack)",
+      "triggers": [],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "qa",
+        "ship",
+        "browser",
+        "gstack",
+        "setup-browser-cookies"
+      ]
+    },
+    {
+      "id": "marketing/meta-ads-analyzer",
+      "name": "meta-ads-analyzer",
+      "domain": "marketing",
+      "path": ".cursor/skills/marketing/meta-ads-analyzer/SKILL.md",
+      "description": "Analyze Meta (Facebook/Instagram) ad performance—campaign structure, breakdowns, marginal vs average CPA, and scaling decisions. Analytical workflow only, not financial or legal advice. Triggers: \"Meta ads\", \"Facebook ads\", \"CPA\", \"ROAS\", \"ad account\", \"Breakdown Effect\".",
+      "triggers": [
+        "Meta ads",
+        "Facebook ads",
+        "CPA",
+        "ROAS",
+        "ad account",
+        "Breakdown Effect"
+      ],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "marketing",
+        "ads",
+        "meta-ads-analyzer"
+      ]
+    },
+    {
+      "id": "meta-tools/autoskill",
+      "name": "autoskill",
+      "domain": "meta-tools",
+      "path": ".cursor/skills/meta-tools/autoskill/SKILL.md",
+      "description": "Observe the user's screen via screenpipe, detect repeated research workflows, match them against existing scientific-agent-skills, and draft new skills (or composition recipes that chain existing ones) for the patterns not yet covered. Use when the user asks to analyze their recent work and propose skills based on what they actually do. Requires the screenpipe daemon (https://github.com/screenpipe/screenpipe) running locally on port 3030 — the skill has no other data source and will refuse to ru",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "meta",
+        "skills",
+        "autoskill"
+      ]
+    },
+    {
+      "id": "meta-tools/reflect-yourself",
+      "name": "reflect-yourself",
+      "domain": "meta-tools",
+      "path": ".cursor/skills/meta-tools/reflect-yourself/SKILL.md",
+      "description": "Self-learning system that captures corrections, discovers workflow patterns, and syncs learnings to skills and rules. Use when ending a session, after corrections, or when the user wants to formalize learnings (v1.1.3).",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "meta",
+        "skills",
+        "reflect-yourself"
+      ]
+    },
+    {
+      "id": "meta-tools/reflect-yourself/skill-examples/phase-kickoff",
+      "name": "phase-kickoff",
+      "domain": "meta-tools",
+      "path": ".cursor/skills/meta-tools/reflect-yourself/skill-examples/phase-kickoff/SKILL.md",
+      "description": "Convert the current phase doc into an ordered execution plan and propose work packages (spec-first + tiered tests), including RTL/Hebrew checks.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "meta",
+        "skills",
+        "phase-kickoff"
+      ]
+    },
+    {
+      "id": "ml-dl/pytorch-lightning",
+      "name": "pytorch-lightning",
+      "domain": "ml-dl",
+      "path": ".cursor/skills/ml-dl/pytorch-lightning/SKILL.md",
+      "description": "Deep learning framework (PyTorch Lightning). Organize PyTorch code into LightningModules, configure Trainers for multi-GPU/TPU, implement data pipelines, callbacks, logging (W&B, TensorBoard), distributed training (DDP, FSDP, DeepSpeed), for scalable neural network training.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ml",
+        "deep-learning",
+        "pytorch-lightning"
+      ]
+    },
+    {
+      "id": "ml-dl/scikit-learn",
+      "name": "scikit-learn",
+      "domain": "ml-dl",
+      "path": ".cursor/skills/ml-dl/scikit-learn/SKILL.md",
+      "description": "Machine learning in Python with scikit-learn. Use when working with supervised learning (classification, regression), unsupervised learning (clustering, dimensionality reduction), model evaluation, hyperparameter tuning, preprocessing, or building ML pipelines. Provides comprehensive reference documentation for algorithms, preprocessing techniques, pipelines, and best practices.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ml",
+        "deep-learning",
+        "scikit-learn"
+      ]
+    },
+    {
+      "id": "ml-dl/scikit-survival",
+      "name": "scikit-survival",
+      "domain": "ml-dl",
+      "path": ".cursor/skills/ml-dl/scikit-survival/SKILL.md",
+      "description": "Comprehensive toolkit for survival analysis and time-to-event modeling in Python using scikit-survival. Use this skill when working with censored survival data, performing time-to-event analysis, fitting Cox models, Random Survival Forests, Gradient Boosting models, or Survival SVMs, evaluating survival predictions with concordance index or Brier score, handling competing risks, or implementing any survival analysis workflow with the scikit-survival library.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ml",
+        "deep-learning",
+        "scikit-survival"
+      ]
+    },
+    {
+      "id": "ml-dl/transformers",
+      "name": "transformers",
+      "domain": "ml-dl",
+      "path": ".cursor/skills/ml-dl/transformers/SKILL.md",
+      "description": "This skill should be used when working with pre-trained transformer models for natural language processing, computer vision, audio, or multimodal tasks. Use for text generation, classification, question answering, translation, summarization, image classification, object detection, speech recognition, and fine-tuning models on custom datasets.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ml",
+        "deep-learning",
+        "transformers"
+      ]
+    },
+    {
+      "id": "mobile/app-store-submission-packager",
+      "name": "app-store-submission-packager",
+      "domain": "mobile",
+      "path": ".cursor/skills/mobile/app-store-submission-packager/SKILL.md",
+      "description": "Prepare iOS App Store and Google Play submissions—metadata, assets, compliance checks, and release checklist. Use before store upload or review submission. Triggers: \"App Store\", \"Play Store\", \"store submission\", \"app review\", \"release checklist\".",
+      "triggers": [
+        "App Store",
+        "Play Store",
+        "store submission",
+        "app review",
+        "release checklist"
+      ],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "mobile",
+        "ios",
+        "android",
+        "app-store-submission-packager"
+      ]
+    },
+    {
+      "id": "mobile/ios-testflight-github-actions",
+      "name": "ios-testflight-github-actions",
+      "domain": "mobile",
+      "path": ".cursor/skills/mobile/ios-testflight-github-actions/SKILL.md",
+      "description": "Set up iOS TestFlight delivery via GitHub Actions—build, sign, upload—with secret hygiene and no auto-push. Triggers: \"TestFlight\", \"iOS CI\", \"Fastlane GitHub Actions\", \"beta release\", \"App Store Connect upload\".",
+      "triggers": [
+        "TestFlight",
+        "iOS CI",
+        "Fastlane GitHub Actions",
+        "beta release",
+        "App Store Connect upload"
+      ],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "mobile",
+        "ios",
+        "android",
+        "ios-testflight-github-actions"
+      ]
+    },
+    {
+      "id": "performance/performance-optimization",
+      "name": "performance-optimization",
+      "domain": "performance",
+      "path": ".cursor/skills/performance/performance-optimization/SKILL.md",
+      "description": ">   Measure, identify bottlenecks, fix, verify, and guard performance regressions.   Use for web vitals, slow APIs, heavy notebooks/pipelines, or video/render workloads.   Triggers: \"performance\", \"optimize\", \"slow\", \"latency\", \"bundle size\", \"profiling\".",
+      "triggers": [
+        "performance",
+        "optimize",
+        "slow",
+        "latency",
+        "bundle size",
+        "profiling"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "performance",
+        "performance-optimization"
+      ]
+    },
+    {
+      "id": "product-growth/product-analytics-experiments",
+      "name": "product-analytics-experiments",
+      "domain": "product-growth",
+      "path": ".cursor/skills/product-growth/product-analytics-experiments/SKILL.md",
+      "description": ">   Product analytics and experimentation—event design, funnel metrics, tracking   plans, and A/B test setup with statistical and operational gates. Use when   defining metrics, launch experiments, or reviewing growth/DS product work.   Triggers: \"A/B test\", \"experiment\", \"funnel\", \"tracking plan\", \"product analytics\".",
+      "triggers": [
+        "A/B test",
+        "experiment",
+        "funnel",
+        "tracking plan",
+        "product analytics"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "product",
+        "growth",
+        "product-analytics-experiments"
+      ]
+    },
+    {
+      "id": "product-growth/product-offer-design",
+      "name": "product-offer-design",
+      "domain": "product-growth",
+      "path": ".cursor/skills/product-growth/product-offer-design/SKILL.md",
+      "description": "Package workflows and capabilities into clear product offers—audience, outcome, scope, and delivery format. Neutral framing without fixed pricing dogma. Triggers: \"product offer\", \"package this\", \"what to sell\", \"positioning\", \"service productization\".",
+      "triggers": [
+        "product offer",
+        "package this",
+        "what to sell",
+        "positioning",
+        "service productization"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "product",
+        "growth",
+        "product-offer-design"
+      ]
+    },
+    {
+      "id": "reflect-yourself",
+      "name": "reflect-yourself",
+      "domain": "reflect-yourself",
+      "path": ".cursor/skills/reflect-yourself/SKILL.md",
+      "description": "Self-learning system that captures corrections, discovers workflow patterns, and syncs learnings to skills and rules. Use when ending a session, after corrections, or when the user wants to formalize learnings (v1.1.3).",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "reflect-yourself"
+      ]
+    },
+    {
+      "id": "reflect-yourself/skill-examples/phase-kickoff",
+      "name": "phase-kickoff",
+      "domain": "reflect-yourself",
+      "path": ".cursor/skills/reflect-yourself/skill-examples/phase-kickoff/SKILL.md",
+      "description": "Convert the current phase doc into an ordered execution plan and propose work packages (spec-first + tiered tests), including RTL/Hebrew checks.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "reflect-yourself",
+        "phase-kickoff"
+      ]
+    },
+    {
+      "id": "reliability-ops/ci-cd-quality-gates",
+      "name": "ci-cd-quality-gates",
+      "domain": "reliability-ops",
+      "path": ".cursor/skills/reliability-ops/ci-cd-quality-gates/SKILL.md",
+      "description": ">   Design lightweight CI quality gates—lint, test tiers, security scans, and merge   policies. Use when setting up or improving pipelines without tying to one stack only.   Triggers: \"CI\", \"quality gate\", \"pipeline\", \"GitHub Actions\", \"pre-merge checks\".",
+      "triggers": [
+        "CI",
+        "quality gate",
+        "pipeline",
+        "GitHub Actions",
+        "pre-merge checks"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ci",
+        "ops",
+        "launch",
+        "observability",
+        "ci-cd-quality-gates"
+      ]
+    },
+    {
+      "id": "reliability-ops/cross-platform-error-handling",
+      "name": "cross-platform-error-handling",
+      "domain": "reliability-ops",
+      "path": ".cursor/skills/reliability-ops/cross-platform-error-handling/SKILL.md",
+      "description": "Design consistent error handling across web, mobile, and React Native—central handlers, user-facing copy, retry, and logging. Triggers: \"error handling\", \"error boundary\", \"toast\", \"React Native errors\", \"global handler\".",
+      "triggers": [
+        "error handling",
+        "error boundary",
+        "toast",
+        "React Native errors",
+        "global handler"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ci",
+        "ops",
+        "launch",
+        "observability",
+        "cross-platform-error-handling"
+      ]
+    },
+    {
+      "id": "reliability-ops/dynamic-config-management",
+      "name": "dynamic-config-management",
+      "domain": "reliability-ops",
+      "path": ".cursor/skills/reliability-ops/dynamic-config-management/SKILL.md",
+      "description": "Manage application configuration—schemas, validation, .env.example, placeholder detection, fail-fast startup. Use when adding env vars or centralizing config. Triggers: \"config\", \"environment variables\", \".env\", \"settings\", \"fail fast\", \"config schema\".",
+      "triggers": [
+        "config",
+        "environment variables"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ci",
+        "ops",
+        "launch",
+        "observability",
+        "dynamic-config-management"
+      ]
+    },
+    {
+      "id": "reliability-ops/observability-slo",
+      "name": "observability-slo",
+      "domain": "reliability-ops",
+      "path": ".cursor/skills/reliability-ops/observability-slo/SKILL.md",
+      "description": ">   Lightweight observability and SLO practice—SLIs, SLO targets, error budgets,   logs, metrics, traces, and alerting for apps and data pipelines.   Use when defining monitoring, on-call alerts, or reliability targets.   Triggers: \"SLO\", \"SLI\", \"observability\", \"alerting\", \"error budget\", \"monitoring\".",
+      "triggers": [
+        "SLO",
+        "SLI",
+        "observability",
+        "alerting",
+        "error budget",
+        "monitoring"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ci",
+        "ops",
+        "launch",
+        "observability",
+        "observability-slo"
+      ]
+    },
+    {
+      "id": "reliability-ops/postmortem-writing",
+      "name": "postmortem-writing",
+      "domain": "reliability-ops",
+      "path": ".cursor/skills/reliability-ops/postmortem-writing/SKILL.md",
+      "description": ">   Write blameless incident postmortems—timeline, impact, root cause, contributing   factors, and actionable follow-ups. Use after outages, SEV incidents, or   significant near-misses.   Triggers: \"postmortem\", \"incident review\", \"RCA\", \"blameless\", \"SEV\".",
+      "triggers": [
+        "postmortem",
+        "incident review",
+        "RCA",
+        "blameless",
+        "SEV"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ci",
+        "ops",
+        "launch",
+        "observability",
+        "postmortem-writing"
+      ]
+    },
+    {
+      "id": "reliability-ops/serverless-debugging",
+      "name": "serverless-debugging",
+      "domain": "reliability-ops",
+      "path": ".cursor/skills/reliability-ops/serverless-debugging/SKILL.md",
+      "description": "Debug serverless and edge functions—limited logs, cold starts, timeouts, env/config mismatches. Use for Lambda, Cloud Functions, Workers, Vercel/Netlify functions. Triggers: \"serverless\", \"Lambda\", \"edge function\", \"cold start\", \"function timeout\".",
+      "triggers": [
+        "serverless",
+        "Lambda",
+        "edge function",
+        "cold start",
+        "function timeout"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ci",
+        "ops",
+        "launch",
+        "observability",
+        "serverless-debugging"
+      ]
+    },
+    {
+      "id": "reliability-ops/shipping-launch-checklist",
+      "name": "shipping-launch-checklist",
+      "domain": "reliability-ops",
+      "path": ".cursor/skills/reliability-ops/shipping-launch-checklist/SKILL.md",
+      "description": ">   Pre-launch and rollout checklist—feature flags, thresholds, rollback, monitoring,   and comms. Use before production releases or risky deploys.   Triggers: \"launch\", \"ship to prod\", \"rollout\", \"release checklist\", \"go live\".",
+      "triggers": [
+        "launch",
+        "ship to prod",
+        "rollout",
+        "release checklist",
+        "go live"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "ci",
+        "ops",
+        "launch",
+        "observability",
+        "shipping-launch-checklist"
+      ]
+    },
+    {
+      "id": "security-appsec/api-security-testing",
+      "name": "api-security-testing",
+      "domain": "security-appsec",
+      "path": ".cursor/skills/security-appsec/api-security-testing/SKILL.md",
+      "description": ">   Security testing checklist for HTTP APIs—authn/z, input validation, rate limits,   sensitive data exposure, and common OWASP API issues. Use when reviewing or   testing REST/GraphQL endpoints before release.   Triggers: \"API security\", \"pen test API\", \"OWASP API\", \"auth test\", \"security test\".",
+      "triggers": [
+        "API security",
+        "pen test API",
+        "OWASP API",
+        "auth test",
+        "security test"
+      ],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "security",
+        "api",
+        "audit",
+        "api-security-testing"
+      ]
+    },
+    {
+      "id": "security-appsec/secure-api-design",
+      "name": "secure-api-design",
+      "domain": "security-appsec",
+      "path": ".cursor/skills/security-appsec/secure-api-design/SKILL.md",
+      "description": ">   Design and implement secure APIs—authentication patterns, authorization models,   input validation, secrets handling, and safe defaults. Use when designing new   endpoints, auth flows, or reviewing API contracts.   Triggers: \"secure API\", \"auth design\", \"JWT\", \"OAuth\", \"API best practices\".",
+      "triggers": [
+        "secure API",
+        "auth design",
+        "JWT",
+        "OAuth",
+        "API best practices"
+      ],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "security",
+        "api",
+        "audit",
+        "secure-api-design"
+      ]
+    },
+    {
+      "id": "security-appsec/skill-supply-chain-audit",
+      "name": "skill-supply-chain-audit",
+      "domain": "security-appsec",
+      "path": ".cursor/skills/security-appsec/skill-supply-chain-audit/SKILL.md",
+      "description": ">   Audit third-party agent skills before install—metadata, triggers, scripts,   network/exfil patterns, and overlap with existing skills. Use before importing   skills from external catalogs or vendoring new SKILL.md files.   Triggers: \"audit skill\", \"import skill\", \"skill security\", \"third-party skill\".",
+      "triggers": [
+        "audit skill",
+        "import skill",
+        "skill security",
+        "third-party skill"
+      ],
+      "risk": "medium",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "security",
+        "api",
+        "audit",
+        "skill-supply-chain-audit"
+      ]
+    },
+    {
+      "id": "visualization/data-viz-storytelling-healy",
+      "name": "data-viz-storytelling-healy",
+      "domain": "visualization",
+      "path": ".cursor/skills/visualization/data-viz-storytelling-healy/SKILL.md",
+      "description": ">   Chọn đúng biểu đồ, kể chuyện với số liệu, và tránh误导 — dựa trên nguyên tắc   từ Kieran Healy (Data Visualization, Princeton 2019) và taxonomy từ AntV   chart-visualization-skills. Dùng khi cần quyết định loại chart, trình bày insight   cho stakeholder, hoặc kiểm tra xem figure có gây hiểu lầm không. Để vẽ Python   thực tế, chuyển sang matplotlib / seaborn / scientific-visualization.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "viz",
+        "charts",
+        "data-viz-storytelling-healy"
+      ]
+    },
+    {
+      "id": "visualization/infographics",
+      "name": "infographics",
+      "domain": "visualization",
+      "path": ".cursor/skills/visualization/infographics/SKILL.md",
+      "description": "Create professional infographics using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Integrates research-lookup and web search for accurate data. Supports 10 infographic types, 8 industry styles, and colorblind-safe palettes.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "viz",
+        "charts",
+        "infographics"
+      ]
+    },
+    {
+      "id": "visualization/matplotlib",
+      "name": "matplotlib",
+      "domain": "visualization",
+      "path": ".cursor/skills/visualization/matplotlib/SKILL.md",
+      "description": "Low-level plotting library for full customization. Use when you need fine-grained control over every plot element, creating novel plot types, or integrating with specific scientific workflows. Export to PNG/PDF/SVG for publication. For quick statistical plots use seaborn; for interactive plots use plotly; for publication-ready multi-panel figures with journal styling, use scientific-visualization.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "viz",
+        "charts",
+        "matplotlib"
+      ]
+    },
+    {
+      "id": "visualization/scientific-visualization",
+      "name": "scientific-visualization",
+      "domain": "visualization",
+      "path": ".cursor/skills/visualization/scientific-visualization/SKILL.md",
+      "description": "Meta-skill for publication-ready figures. Use when creating journal submission figures requiring multi-panel layouts, significance annotations, error bars, colorblind-safe palettes, and specific journal formatting (Nature, Science, Cell). Orchestrates matplotlib/seaborn/plotly with publication styles. For quick exploration use seaborn or plotly directly.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "viz",
+        "charts",
+        "scientific-visualization"
+      ]
+    },
+    {
+      "id": "visualization/seaborn",
+      "name": "seaborn",
+      "domain": "visualization",
+      "path": ".cursor/skills/visualization/seaborn/SKILL.md",
+      "description": "Statistical visualization with pandas integration. Use for quick exploration of distributions, relationships, and categorical comparisons with attractive defaults. Best for box plots, violin plots, pair plots, heatmaps. Built on matplotlib. For interactive plots use plotly; for publication styling use scientific-visualization.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "viz",
+        "charts",
+        "seaborn"
+      ]
+    },
+    {
+      "id": "voltagent",
+      "name": "voltagent-subagents",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/SKILL.md",
+      "description": ">-   Cursor skills converted from VoltAgent awesome-claude-code-subagents (DS/ML/AI/   research, product, orchestration). Use when you want role-based playbooks aligned   with data science and stakeholder workflows.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "voltagent-subagents"
+      ]
+    },
+    {
+      "id": "voltagent/business-product/business-analyst",
+      "name": "business-analyst",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/business-product/business-analyst/SKILL.md",
+      "description": "Use when analyzing business processes, gathering requirements from stakeholders, or identifying process improvement opportunities to drive operational efficiency and measurable business value.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "business-analyst"
+      ]
+    },
+    {
+      "id": "voltagent/business-product/customer-success-manager",
+      "name": "customer-success-manager",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/business-product/customer-success-manager/SKILL.md",
+      "description": "Use this agent when you need to assess customer health, develop retention strategies, identify upsell opportunities, or maximize customer lifetime value. Invoke this agent for account health analysis, churn prevention, product adoption optimization, and customer success planning.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "customer-success-manager"
+      ]
+    },
+    {
+      "id": "voltagent/business-product/product-manager",
+      "name": "product-manager",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/business-product/product-manager/SKILL.md",
+      "description": "Use this agent when you need to make product strategy decisions, prioritize features, or define roadmap plans based on user needs and business goals.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "product-manager"
+      ]
+    },
+    {
+      "id": "voltagent/business-product/project-manager",
+      "name": "project-manager",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/business-product/project-manager/SKILL.md",
+      "description": "Use this agent when you need to establish project plans, track execution progress, manage risks, control budget/schedule, and coordinate stakeholders across complex initiatives.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "project-manager"
+      ]
+    },
+    {
+      "id": "voltagent/business-product/scrum-master",
+      "name": "scrum-master",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/business-product/scrum-master/SKILL.md",
+      "description": "Use when teams need facilitation, process optimization, velocity improvement, or agile ceremony management\\u2014especially for sprint planning, retrospectives, impediment removal, and scaling agile practices across multiple teams.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "scrum-master"
+      ]
+    },
+    {
+      "id": "voltagent/business-product/technical-writer",
+      "name": "technical-writer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/business-product/technical-writer/SKILL.md",
+      "description": "Use this agent when you need to create, improve, or maintain technical documentation including API references, user guides, SDK documentation, and getting-started guides.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "technical-writer"
+      ]
+    },
+    {
+      "id": "voltagent/business-product/ux-researcher",
+      "name": "ux-researcher",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/business-product/ux-researcher/SKILL.md",
+      "description": "Use this agent when you need to conduct user research, analyze user behavior, or generate actionable insights to validate design decisions and uncover user needs. Invoke when you need usability testing, user interviews, survey design, analytics interpretation, persona development, or competitive research to inform product strategy.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "ux-researcher"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/ai-engineer",
+      "name": "ai-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/ai-engineer/SKILL.md",
+      "description": "Use this agent when architecting, implementing, or optimizing end-to-end AI systems\\u2014from model selection and training pipelines to production deployment and monitoring.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "ai-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/data-analyst",
+      "name": "data-analyst",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/data-analyst/SKILL.md",
+      "description": "Use when you need to extract insights from business data, create dashboards and reports, or perform statistical analysis to support decision-making.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "data-analyst"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/data-engineer",
+      "name": "data-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/data-engineer/SKILL.md",
+      "description": "Use this agent when you need to design, build, or optimize data pipelines, ETL/ELT processes, and data infrastructure. Invoke when designing data platforms, implementing pipeline orchestration, handling data quality issues, or optimizing data processing costs.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "data-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/data-scientist",
+      "name": "data-scientist",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/data-scientist/SKILL.md",
+      "description": "Use this agent when you need to analyze data patterns, build predictive models, or extract statistical insights from datasets. Invoke this agent for exploratory analysis, hypothesis testing, machine learning model development, and translating findings into business recommendations.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "data-scientist"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/database-optimizer",
+      "name": "database-optimizer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/database-optimizer/SKILL.md",
+      "description": "Use this agent when you need to analyze slow queries, optimize database performance across multiple systems, or implement indexing strategies to improve query execution.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "database-optimizer"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/llm-architect",
+      "name": "llm-architect",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/llm-architect/SKILL.md",
+      "description": "Use when designing LLM systems for production, implementing fine-tuning or RAG architectures, optimizing inference serving infrastructure, or managing multi-model deployments.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "llm-architect"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/machine-learning-engineer",
+      "name": "machine-learning-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/machine-learning-engineer/SKILL.md",
+      "description": "Use this agent when you need to deploy, optimize, or serve machine learning models at scale in production environments.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "machine-learning-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/ml-engineer",
+      "name": "ml-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/ml-engineer/SKILL.md",
+      "description": "Use this agent when building production ML systems requiring model training pipelines, model serving infrastructure, performance optimization, and automated retraining.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "ml-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/mlops-engineer",
+      "name": "mlops-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/mlops-engineer/SKILL.md",
+      "description": "Use this agent when you need to design and implement ML infrastructure, set up CI/CD for machine learning models, establish model versioning systems, or optimize ML platforms for reliability and automation. Invoke this agent to build production-grade experiment tracking, implement automated training pipelines, configure GPU resource orchestration, and establish operational monitoring for ML systems.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "mlops-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/nlp-engineer",
+      "name": "nlp-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/nlp-engineer/SKILL.md",
+      "description": "Use when building production NLP systems, implementing text processing pipelines, developing language models, or solving domain-specific NLP tasks like named entity recognition, sentiment analysis, or machine translation.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "nlp-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/postgres-pro",
+      "name": "postgres-pro",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/postgres-pro/SKILL.md",
+      "description": "Use when you need to optimize PostgreSQL performance, design high-availability replication, or troubleshoot database issues at scale. Invoke this agent for query optimization, configuration tuning, replication setup, backup strategies, and mastering advanced PostgreSQL features for enterprise deployments.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "postgres-pro"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/prompt-engineer",
+      "name": "prompt-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/prompt-engineer/SKILL.md",
+      "description": "Use this agent when you need to design, optimize, test, or evaluate prompts for large language models in production systems.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "prompt-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/data-ai/reinforcement-learning-engineer",
+      "name": "reinforcement-learning-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/data-ai/reinforcement-learning-engineer/SKILL.md",
+      "description": "Use when designing RL environments, training agents with reward optimization, implementing policy gradient methods, or deploying decision-making systems for robotics, gaming, and autonomous operations.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "reinforcement-learning-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/dev-workflow/documentation-engineer",
+      "name": "documentation-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/dev-workflow/documentation-engineer/SKILL.md",
+      "description": "Use this agent when you need to create, architect, or overhaul comprehensive documentation systems including API docs, tutorials, guides, and developer-friendly content that keeps pace with code changes.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "documentation-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/dev-workflow/git-workflow-manager",
+      "name": "git-workflow-manager",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/dev-workflow/git-workflow-manager/SKILL.md",
+      "description": "Use this agent when you need to design, establish, or optimize Git workflows, branching strategies, and merge management for a project or team.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "git-workflow-manager"
+      ]
+    },
+    {
+      "id": "voltagent/dev-workflow/refactoring-specialist",
+      "name": "refactoring-specialist",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/dev-workflow/refactoring-specialist/SKILL.md",
+      "description": "Use when you need to transform poorly structured, complex, or duplicated code into clean, maintainable systems while preserving all existing behavior.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "refactoring-specialist"
+      ]
+    },
+    {
+      "id": "voltagent/fintech-risk/fintech-engineer",
+      "name": "fintech-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/fintech-risk/fintech-engineer/SKILL.md",
+      "description": "Use when building payment systems, financial integrations, or compliance-heavy financial applications that require secure transaction processing, regulatory adherence, and high transaction accuracy.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "fintech-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/fintech-risk/healthcare-admin",
+      "name": "healthcare-admin",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/fintech-risk/healthcare-admin/SKILL.md",
+      "description": "Use when working on healthcare administration tasks including revenue cycle management, HIPAA/compliance auditing, medical coding (ICD-10, CPT, DRGs), CMS cost reports, payer contract analysis, quality improvement, clinical operations, health IT/interoperability, population health, and pharmacy benefits.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "healthcare-admin"
+      ]
+    },
+    {
+      "id": "voltagent/fintech-risk/quant-analyst",
+      "name": "quant-analyst",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/fintech-risk/quant-analyst/SKILL.md",
+      "description": "Use this agent when you need to develop quantitative trading strategies, build financial models with rigorous mathematical foundations, or conduct advanced risk analytics for derivatives and portfolios. Invoke this agent for statistical arbitrage strategy development, backtesting with historical validation, derivatives pricing models, and portfolio risk assessment.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "quant-analyst"
+      ]
+    },
+    {
+      "id": "voltagent/fintech-risk/risk-manager",
+      "name": "risk-manager",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/fintech-risk/risk-manager/SKILL.md",
+      "description": "Use this agent when you need to identify, quantify, and mitigate enterprise-level risks across financial, operational, regulatory, and strategic domains. Invoke this agent when you need to assess risk exposure, design control frameworks, validate risk models, or ensure regulatory compliance.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "risk-manager"
+      ]
+    },
+    {
+      "id": "voltagent/infra/deployment-engineer",
+      "name": "deployment-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/infra/deployment-engineer/SKILL.md",
+      "description": "Use this agent when designing, building, or optimizing CI/CD pipelines and deployment automation strategies.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "deployment-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/languages/python-pro",
+      "name": "python-pro",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/languages/python-pro/SKILL.md",
+      "description": "Use this agent when you need to build type-safe, production-ready Python code for web APIs, system utilities, or complex applications requiring modern async patterns and extensive type coverage.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "python-pro"
+      ]
+    },
+    {
+      "id": "voltagent/languages/sql-pro",
+      "name": "sql-pro",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/languages/sql-pro/SKILL.md",
+      "description": "Use this agent when you need to optimize complex SQL queries, design efficient database schemas, or solve performance issues across PostgreSQL, MySQL, SQL Server, and Oracle requiring advanced query optimization, index strategies, or data warehouse patterns.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "sql-pro"
+      ]
+    },
+    {
+      "id": "voltagent/orchestration/context-manager",
+      "name": "context-manager",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/orchestration/context-manager/SKILL.md",
+      "description": "Use for managing shared state, information retrieval, and data synchronization when multiple agents need coordinated access to context and metadata.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "context-manager"
+      ]
+    },
+    {
+      "id": "voltagent/orchestration/error-coordinator",
+      "name": "error-coordinator",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/orchestration/error-coordinator/SKILL.md",
+      "description": "Use this agent when distributed system errors occur and need coordinated handling across multiple components, or when you need to implement comprehensive error recovery strategies with automated failure detection and cascade prevention.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "error-coordinator"
+      ]
+    },
+    {
+      "id": "voltagent/orchestration/knowledge-synthesizer",
+      "name": "knowledge-synthesizer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/orchestration/knowledge-synthesizer/SKILL.md",
+      "description": "Use when you need to extract actionable patterns from agent interactions, synthesize insights across multiple workflows, and enable organizational learning from collective experience.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "knowledge-synthesizer"
+      ]
+    },
+    {
+      "id": "voltagent/orchestration/multi-agent-coordinator",
+      "name": "multi-agent-coordinator",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/orchestration/multi-agent-coordinator/SKILL.md",
+      "description": "Use when coordinating multiple concurrent agents that need to communicate, share state, synchronize work, and handle distributed failures across a system.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "multi-agent-coordinator"
+      ]
+    },
+    {
+      "id": "voltagent/orchestration/task-distributor",
+      "name": "task-distributor",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/orchestration/task-distributor/SKILL.md",
+      "description": "Use when distributing tasks across multiple agents or workers, managing queues, and balancing workloads to maximize throughput while respecting priorities and deadlines.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "task-distributor"
+      ]
+    },
+    {
+      "id": "voltagent/quality-engineering/code-reviewer",
+      "name": "code-reviewer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/quality-engineering/code-reviewer/SKILL.md",
+      "description": "Use this agent when you need to conduct comprehensive code reviews focusing on code quality, security vulnerabilities, and best practices.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "code-reviewer"
+      ]
+    },
+    {
+      "id": "voltagent/quality-engineering/debugger",
+      "name": "debugger",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/quality-engineering/debugger/SKILL.md",
+      "description": "Use this agent when you need to diagnose and fix bugs, identify root causes of failures, or analyze error logs and stack traces to resolve issues.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "debugger"
+      ]
+    },
+    {
+      "id": "voltagent/quality-engineering/performance-engineer",
+      "name": "performance-engineer",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/quality-engineering/performance-engineer/SKILL.md",
+      "description": "Use this agent when you need to identify and eliminate performance bottlenecks in applications, databases, or infrastructure systems, and when baseline performance metrics need improvement.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "performance-engineer"
+      ]
+    },
+    {
+      "id": "voltagent/quality-engineering/qa-expert",
+      "name": "qa-expert",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/quality-engineering/qa-expert/SKILL.md",
+      "description": "Use this agent when you need comprehensive quality assurance strategy, test planning across the entire development cycle, or quality metrics analysis to improve overall software quality.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "qa-expert"
+      ]
+    },
+    {
+      "id": "voltagent/research-analysis/competitive-analyst",
+      "name": "competitive-analyst",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/research-analysis/competitive-analyst/SKILL.md",
+      "description": "Use when you need to analyze direct and indirect competitors, benchmark against market leaders, or develop strategies to strengthen competitive positioning and market advantage.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "competitive-analyst"
+      ]
+    },
+    {
+      "id": "voltagent/research-analysis/data-researcher",
+      "name": "data-researcher",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/research-analysis/data-researcher/SKILL.md",
+      "description": "Use this agent when you need to discover, collect, and validate data from multiple sources to fuel analysis and decision-making. Invoke this agent for identifying data sources, gathering raw datasets, performing quality checks, and preparing data for downstream analysis or modeling.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "data-researcher"
+      ]
+    },
+    {
+      "id": "voltagent/research-analysis/market-researcher",
+      "name": "market-researcher",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/research-analysis/market-researcher/SKILL.md",
+      "description": "Use this agent when you need to analyze markets, understand consumer behavior, assess competitive landscapes, and size opportunities to inform business strategy and market entry decisions.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "market-researcher"
+      ]
+    },
+    {
+      "id": "voltagent/research-analysis/project-idea-validator",
+      "name": "project-idea-validator",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/research-analysis/project-idea-validator/SKILL.md",
+      "description": "Use this agent when you need an idea pressure-tested with brutal honesty, competitor teardown, market validation, and clear go/no-go guidance before building.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "project-idea-validator"
+      ]
+    },
+    {
+      "id": "voltagent/research-analysis/research-analyst",
+      "name": "research-analyst",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/research-analysis/research-analyst/SKILL.md",
+      "description": "Use this agent when you need comprehensive research across multiple sources with synthesis of findings into actionable insights, trend identification, and detailed reporting.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "research-analyst"
+      ]
+    },
+    {
+      "id": "voltagent/research-analysis/scientific-literature-researcher",
+      "name": "scientific-literature-researcher",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/research-analysis/scientific-literature-researcher/SKILL.md",
+      "description": "Use when you need to search scientific literature and retrieve structured experimental data from published studies. Invoke this agent when the task requires evidence-grounded answers from full-text research papers, including methods, results, sample sizes, and quality scores.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "scientific-literature-researcher"
+      ]
+    },
+    {
+      "id": "voltagent/research-analysis/search-specialist",
+      "name": "search-specialist",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/research-analysis/search-specialist/SKILL.md",
+      "description": "Use when you need to find specific information across multiple sources using advanced search strategies, query optimization, and targeted information retrieval. Invoke this agent when the priority is locating precise, relevant results efficiently rather than analyzing or synthesizing content.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "search-specialist"
+      ]
+    },
+    {
+      "id": "voltagent/research-analysis/trend-analyst",
+      "name": "trend-analyst",
+      "domain": "voltagent",
+      "path": ".cursor/skills/voltagent/research-analysis/trend-analyst/SKILL.md",
+      "description": "Use when analyzing emerging patterns, predicting industry shifts, or developing future scenarios to inform strategic planning and competitive positioning.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "persona",
+        "subagent",
+        "roles",
+        "trend-analyst"
+      ]
+    },
+    {
+      "id": "writing-docs/docx",
+      "name": "docx",
+      "domain": "writing-docs",
+      "path": ".cursor/skills/writing-docs/docx/SKILL.md",
+      "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, ",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "docs",
+        "writing",
+        "docx"
+      ]
+    },
+    {
+      "id": "writing-docs/pdf",
+      "name": "pdf",
+      "domain": "writing-docs",
+      "path": ".cursor/skills/writing-docs/pdf/SKILL.md",
+      "description": "Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "docs",
+        "writing",
+        "pdf"
+      ]
+    },
+    {
+      "id": "writing-docs/pptx",
+      "name": "pptx",
+      "domain": "writing-docs",
+      "path": ".cursor/skills/writing-docs/pptx/SKILL.md",
+      "description": ">   Create and edit PowerPoint presentations (.pptx)—slides, layouts, speaker notes,   and export. Use when the deliverable is a deck for stakeholders, workshops,   or model readouts. Complements docx/pdf/xlsx skills.   Triggers: \"PowerPoint\", \"pptx\", \"slides\", \"deck\", \"presentation\".",
+      "triggers": [
+        "PowerPoint",
+        "pptx",
+        "slides",
+        "deck",
+        "presentation"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "docs",
+        "writing",
+        "pptx"
+      ]
+    },
+    {
+      "id": "writing-docs/prose-polish",
+      "name": "prose-polish",
+      "domain": "writing-docs",
+      "path": ".cursor/skills/writing-docs/prose-polish/SKILL.md",
+      "description": ">   Polish technical and stakeholder prose—clarity, tone, structure, and reducing   generic AI-writing patterns. Use for blog posts, knowledge-base pages, READMEs, exec   summaries, and user-facing copy before publish.   Triggers: \"edit prose\", \"polish writing\", \"sounds like AI\", \"copy edit\", \"tone\".",
+      "triggers": [
+        "edit prose",
+        "polish writing",
+        "sounds like AI",
+        "copy edit",
+        "tone"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "docs",
+        "writing",
+        "prose-polish"
+      ]
+    },
+    {
+      "id": "writing-docs/scientific-writing",
+      "name": "scientific-writing",
+      "domain": "writing-docs",
+      "path": ".cursor/skills/writing-docs/scientific-writing/SKILL.md",
+      "description": "Core skill for the deep research and writing tool. Write scientific manuscripts in full paragraphs (never bullet points). Use two-stage process with (1) section outlines with key points using research-lookup then (2) convert to flowing prose. IMRAD structure, citations (APA/AMA/Vancouver), figures/tables, reporting guidelines (CONSORT/STROBE/PRISMA), for research papers and journal submissions.",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "docs",
+        "writing",
+        "scientific-writing"
+      ]
+    },
+    {
+      "id": "writing-docs/sympy",
+      "name": "sympy",
+      "domain": "writing-docs",
+      "path": ".cursor/skills/writing-docs/sympy/SKILL.md",
+      "description": "Use this skill when working with symbolic mathematics in Python. This skill should be used for symbolic computation tasks including solving equations algebraically, performing calculus operations (derivatives, integrals, limits), manipulating algebraic expressions, working with matrices symbolically, physics calculations, number theory problems, geometry computations, and generating executable code from mathematical expressions. Apply this skill when the user needs exact symbolic results rather ",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "docs",
+        "writing",
+        "sympy"
+      ]
+    },
+    {
+      "id": "writing-docs/xlsx",
+      "name": "xlsx",
+      "domain": "writing-docs",
+      "path": ".cursor/skills/writing-docs/xlsx/SKILL.md",
+      "description": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \\\"the xlsx in m",
+      "triggers": [],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "docs",
+        "writing",
+        "xlsx"
+      ]
+    }
+  ]
+}

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Generate registry/skills.json and verify sync with .cursor/skills."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CURSOR_ROOT = ROOT / ".cursor" / "skills"
+REGISTRY_DIR = ROOT / "registry"
+SKILLS_JSON = REGISTRY_DIR / "skills.json"
+BUNDLES_JSON = REGISTRY_DIR / "bundles.json"
+
+DOMAIN_RISK = {
+    "security-appsec": "medium",
+    "gstack": "medium",
+    "frontend-engineering": "medium",
+    "mobile": "medium",
+    "marketing": "medium",
+    "ai-agent-systems": "low",
+    "reliability-ops": "low",
+    "core-workflow": "low",
+}
+
+DOMAIN_TAGS: dict[str, list[str]] = {
+    "core-workflow": ["workflow", "planning", "review", "testing"],
+    "ai-agent-systems": ["agents", "mcp", "rag", "tools"],
+    "security-appsec": ["security", "api", "audit"],
+    "reliability-ops": ["ci", "ops", "launch", "observability"],
+    "frontend-engineering": ["frontend", "ui", "browser"],
+    "gstack": ["qa", "ship", "browser", "gstack"],
+    "voltagent": ["persona", "subagent", "roles"],
+    "ml-dl": ["ml", "deep-learning"],
+    "analysis-stats": ["statistics", "shap", "modeling"],
+    "data-compute": ["data", "etl", "compute"],
+    "eda-research": ["eda", "research"],
+    "visualization": ["viz", "charts"],
+    "writing-docs": ["docs", "writing"],
+    "meta-tools": ["meta", "skills"],
+    "performance": ["performance"],
+    "product-growth": ["product", "growth"],
+    "mobile": ["mobile", "ios", "android"],
+    "marketing": ["marketing", "ads"],
+    "architecture": ["architecture", "diagrams"],
+}
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    raw = text[3:end]
+    fm: dict[str, str] = {}
+    key: str | None = None
+    buf: list[str] = []
+    for line in raw.splitlines():
+        if re.match(r"^[a-zA-Z0-9_-]+:\s*", line) and not line.startswith(" "):
+            if key is not None:
+                fm[key] = "\n".join(buf).strip().strip('"').strip("'")
+            key, _, val = line.partition(":")
+            key = key.strip()
+            buf = [val.strip()]
+        elif key is not None:
+            buf.append(line)
+    if key is not None:
+        fm[key] = "\n".join(buf).strip().strip('"').strip("'")
+    return fm
+
+
+def extract_triggers(description: str) -> list[str]:
+    m = re.search(r'Triggers:\s*(.+?)(?:\.|$)', description, flags=re.I | re.S)
+    if not m:
+        return []
+    chunk = m.group(1)
+    return [t.strip().strip('"').strip("'") for t in re.findall(r'"([^"]+)"', chunk)]
+
+
+def skill_id(path: Path) -> str:
+    rel = path.relative_to(CURSOR_ROOT)
+    if rel.name == "SKILL.md":
+        return str(rel.parent).replace("\\", "/")
+    return str(rel).replace("\\", "/")
+
+
+def domain_of(skill_id_str: str) -> str:
+    return skill_id_str.split("/", 1)[0] if "/" in skill_id_str else skill_id_str
+
+
+def collect_skills() -> list[dict]:
+    entries: list[dict] = []
+    for skill_md in sorted(CURSOR_ROOT.rglob("SKILL.md")):
+        rel = skill_id(skill_md)
+        text = skill_md.read_text(encoding="utf-8")
+        fm = parse_frontmatter(text)
+        name = fm.get("name", skill_md.parent.name)
+        desc = fm.get("description", "").replace("\n", " ").strip()
+        dom = domain_of(rel)
+        tags = list(DOMAIN_TAGS.get(dom, [dom]))
+        if name not in tags:
+            tags.append(name)
+        entries.append(
+            {
+                "id": rel,
+                "name": name,
+                "domain": dom,
+                "path": f".cursor/skills/{rel}/SKILL.md",
+                "description": desc[:500],
+                "triggers": extract_triggers(desc),
+                "risk": DOMAIN_RISK.get(dom, "low"),
+                "formats": ["cursor", "claude"],
+                "source": "awesome-agent-skill",
+                "license": "MIT",
+                "tags": tags[:8],
+            }
+        )
+    return entries
+
+
+def load_bundles() -> dict:
+    if not BUNDLES_JSON.exists():
+        raise SystemExit(f"Missing {BUNDLES_JSON}")
+    return json.loads(BUNDLES_JSON.read_text(encoding="utf-8"))
+
+
+def validate_bundles(skills: list[dict]) -> list[str]:
+    errors: list[str] = []
+    skill_ids = {s["id"] for s in skills}
+    domain_skills: dict[str, list[str]] = {}
+    for s in skills:
+        domain_skills.setdefault(s["domain"], []).append(s["id"])
+
+    data = load_bundles()
+    for bundle in data.get("bundles", []):
+        bid = bundle.get("id", "?")
+        for sid in bundle.get("skills", []):
+            if sid not in skill_ids:
+                errors.append(f"bundle {bid}: unknown skill id {sid}")
+        for dom in bundle.get("domains", []):
+            if dom not in domain_skills:
+                errors.append(f"bundle {bid}: unknown domain {dom}")
+    return errors
+
+
+def build_payload(skills: list[dict]) -> dict:
+    return {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "schema_version": 1,
+        "count": len(skills),
+        "skills": skills,
+    }
+
+
+def registry_body(payload: dict) -> dict:
+    """Stable subset for sync checks (ignore generated_at)."""
+    return {
+        "schema_version": payload["schema_version"],
+        "count": payload["count"],
+        "skills": payload["skills"],
+    }
+
+
+def check_sync(payload: dict) -> list[str]:
+    if not SKILLS_JSON.exists():
+        return ["registry/skills.json is missing; run scripts/generate-registry.py"]
+    committed = json.loads(SKILLS_JSON.read_text(encoding="utf-8"))
+    if registry_body(payload) != registry_body(committed):
+        return ["registry/skills.json is out of date; run scripts/generate-registry.py"]
+    return []
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv
+    skills = collect_skills()
+    payload = build_payload(skills)
+
+    errors = validate_bundles(skills)
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    if check_only:
+        sync_errors = check_sync(payload)
+        if sync_errors:
+            for e in sync_errors:
+                print(f"ERROR: {e}", file=sys.stderr)
+            return 1
+        print(f"Registry OK ({len(skills)} skills)")
+        return 0
+
+    REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+    SKILLS_JSON.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Wrote {len(skills)} skills to {SKILLS_JSON}")
+    print("Bundles validated against skills registry")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install/install-bundle.sh
+++ b/scripts/install/install-bundle.sh
@@ -5,9 +5,7 @@ usage() {
   cat <<'EOF'
 Usage: install-bundle.sh <bundle> <target-project> [--format cursor|claude|both]
 
-Bundles:
-  starter   core-workflow + security-appsec + reliability-ops
-  full      all top-level domains
+Bundles are defined in registry/bundles.json (starter, ship-ready, agent-builder, data-scientist, security-reviewer, full).
 EOF
 }
 
@@ -27,21 +25,29 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 INSTALL="${SCRIPT_DIR}/install-domain.sh"
 
-case "${BUNDLE}" in
-  starter)
-    DOMAINS="core-workflow security-appsec reliability-ops"
-    ;;
-  full)
-    DOMAINS="$(find "${REPO_ROOT}/.cursor/skills" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort | tr '\n' ' ')"
-    ;;
-  *)
-    echo "Unknown bundle: ${BUNDLE}" >&2
-    exit 1
-    ;;
-esac
+INSTALL_SKILL="${SCRIPT_DIR}/install-skill.sh"
+RESOLVE="${REPO_ROOT}/scripts/resolve-bundle.py"
 
-for domain in ${DOMAINS}; do
-  bash "${INSTALL}" "${domain}" "${TARGET}" --format "${FORMAT}"
-done
+if ! PLAN="$(python3 "${RESOLVE}" "${BUNDLE}")"; then
+  exit 1
+fi
+
+while IFS= read -r line; do
+  [[ -z "${line}" ]] && continue
+  kind="${line%%:*}"
+  value="${line#*:}"
+  case "${kind}" in
+    domain)
+      bash "${INSTALL}" "${value}" "${TARGET}" --format "${FORMAT}"
+      ;;
+    skill)
+      bash "${INSTALL_SKILL}" "${value}" "${TARGET}" --format "${FORMAT}"
+      ;;
+    *)
+      echo "Unknown plan entry: ${line}" >&2
+      exit 1
+      ;;
+  esac
+done <<< "${PLAN}"
 
 echo "Bundle '${BUNDLE}' installed into ${TARGET}"

--- a/scripts/install/install-skill.sh
+++ b/scripts/install/install-skill.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: install-skill.sh <skill-id> <target-project> [--format cursor|claude|both]
+
+Example:
+  install-skill.sh core-workflow/verify-before-done ~/my-app --format cursor
+EOF
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+SKILL_ID="$1"
+TARGET="$2"
+FORMAT="both"
+if [[ "${3:-}" == "--format" && -n "${4:-}" ]]; then
+  FORMAT="$4"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SRC="${REPO_ROOT}/.cursor/skills/${SKILL_ID}"
+CLAUDE_SRC="${REPO_ROOT}/.claude/skills/${SKILL_ID}"
+
+if [[ ! -d "${SRC}" ]]; then
+  echo "Skill not found: ${SKILL_ID}" >&2
+  exit 1
+fi
+
+mkdir -p "${TARGET}/.cursor/skills" "${TARGET}/.claude/skills"
+
+if [[ "${FORMAT}" == "cursor" || "${FORMAT}" == "both" ]]; then
+  rm -rf "${TARGET}/.cursor/skills/${SKILL_ID}"
+  mkdir -p "$(dirname "${TARGET}/.cursor/skills/${SKILL_ID}")"
+  cp -R "${SRC}" "${TARGET}/.cursor/skills/${SKILL_ID}"
+fi
+
+if [[ "${FORMAT}" == "claude" || "${FORMAT}" == "both" ]]; then
+  if [[ -d "${CLAUDE_SRC}" ]]; then
+    rm -rf "${TARGET}/.claude/skills/${SKILL_ID}"
+    mkdir -p "$(dirname "${TARGET}/.claude/skills/${SKILL_ID}")"
+    cp -R "${CLAUDE_SRC}" "${TARGET}/.claude/skills/${SKILL_ID}"
+  fi
+fi
+
+echo "Installed skill ${SKILL_ID} into ${TARGET}"

--- a/scripts/resolve-bundle.py
+++ b/scripts/resolve-bundle.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Print bundle install plan: domains and explicit skill ids (one per line, prefixed)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLES_JSON = ROOT / "registry" / "bundles.json"
+CURSOR_ROOT = ROOT / ".cursor" / "skills"
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: resolve-bundle.py <bundle-id>", file=sys.stderr)
+        return 1
+    bundle_id = sys.argv[1]
+    data = json.loads(BUNDLES_JSON.read_text(encoding="utf-8"))
+    bundle = next((b for b in data["bundles"] if b["id"] == bundle_id), None)
+    if bundle is None:
+        print(f"Unknown bundle: {bundle_id}", file=sys.stderr)
+        return 1
+
+    if bundle.get("install_all_domains"):
+        for d in sorted(p.name for p in CURSOR_ROOT.iterdir() if p.is_dir()):
+            print(f"domain:{d}")
+        return 0
+
+    for dom in bundle.get("domains", []):
+        print(f"domain:{dom}")
+    for sid in bundle.get("skills", []):
+        print(f"skill:{sid}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `registry/skills.json` (173 skills) generated by `scripts/generate-registry.py`
- Add `registry/bundles.json` with bundles: starter, ship-ready, agent-builder, data-scientist, security-reviewer, full
- Wire `install-bundle.sh` to registry via `resolve-bundle.py`; add `install-skill.sh` for explicit skill ids
- CI: `generate-registry.py --check` on every PR

## Test plan
- [ ] `python3 scripts/generate-registry.py --check`
- [ ] `python3 scripts/validate-skills.py`
- [ ] `bash scripts/install/install-bundle.sh ship-ready /tmp/test --format cursor`

Made with [Cursor](https://cursor.com)