### PR TITLE
SkillHub Phase 1: registry v2 metadata & count drift doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Stars](https://img.shields.io/github/stars/charlieviettq/awesome-agent-skill?style=for-the-badge&logo=github&color=60a5fa)](https://github.com/charlieviettq/awesome-agent-skill/stargazers)
 [![License: MIT](https://img.shields.io/badge/license-MIT-22c55e?style=for-the-badge)](LICENSE)
-[![Skills](https://img.shields.io/badge/skills-170-8b5cf6?style=for-the-badge)](.cursor/skills)
+[![Skills](https://img.shields.io/badge/skills-178-8b5cf6?style=for-the-badge)](.cursor/skills)
 [![Formats](https://img.shields.io/badge/formats-Cursor%20%2B%20Claude-0ea5e9?style=for-the-badge)](#quickstart)
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 [![Last commit](https://img.shields.io/github/last-commit/charlieviettq/awesome-agent-skill?style=for-the-badge&color=f97316)](https://github.com/charlieviettq/awesome-agent-skill/commits/main)

--- a/docs/metrics/2026-05.md
+++ b/docs/metrics/2026-05.md
@@ -2,7 +2,7 @@
 
 ## Snapshot
 
-- Cursor `SKILL.md` files: **173**
+- Cursor `SKILL.md` files: **178**
 - Claude mapped skills: **170** (see `scripts/claude-skill-map.json`)
 
 - Stars: **6**

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-05-25T10:19:21Z",
-  "schema_version": 1,
-  "count": 173,
+  "generated_at": "2026-05-27T12:21:23Z",
+  "schema_version": 2,
+  "count": 178,
   "skills": [
     {
       "id": "ai-agent-systems/agent-evaluation",
@@ -9,7 +9,14 @@
       "domain": "ai-agent-systems",
       "path": ".cursor/skills/ai-agent-systems/agent-evaluation/SKILL.md",
       "description": ">   Evaluate LLM agents and tool-using workflows—task success, tool accuracy,   latency/cost, safety, and regression suites. Use when shipping agent features,   comparing prompts/models, or debugging agent failures.   Triggers: \"agent eval\", \"benchmark agent\", \"tool accuracy\", \"agent regression\".",
+      "summary": ">   Evaluate LLM agents and tool-using workflows—task success, tool accuracy,   latency/cost, safety, and regression suites. Use when shipping agent features,   comparing prompts/models, or debugging agent failures.   Triggers: \"agent eval\"",
       "triggers": [
+        "agent eval",
+        "benchmark agent",
+        "tool accuracy",
+        "agent regression"
+      ],
+      "trigger_phrases": [
         "agent eval",
         "benchmark agent",
         "tool accuracy",
@@ -28,7 +35,15 @@
         "rag",
         "tools",
         "agent-evaluation"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "ai-agent-systems/agent-tool-contracts",
@@ -36,7 +51,14 @@
       "domain": "ai-agent-systems",
       "path": ".cursor/skills/ai-agent-systems/agent-tool-contracts/SKILL.md",
       "description": ">   Design agent tools and CLI surfaces—schemas, naming, errors, idempotency, and   discoverability for LLM callers. Use when defining tools for agents, SDKs,   or AI-native CLIs.   Triggers: \"tool schema\", \"agent tool\", \"function calling\", \"AI CLI\".",
+      "summary": ">   Design agent tools and CLI surfaces—schemas, naming, errors, idempotency, and   discoverability for LLM callers. Use when defining tools for agents, SDKs,   or AI-native CLIs.   Triggers: \"tool schema\", \"agent tool\", \"function calling\",",
       "triggers": [
+        "tool schema",
+        "agent tool",
+        "function calling",
+        "AI CLI"
+      ],
+      "trigger_phrases": [
         "tool schema",
         "agent tool",
         "function calling",
@@ -55,7 +77,15 @@
         "rag",
         "tools",
         "agent-tool-contracts"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "ai-agent-systems/context-window-management",
@@ -63,7 +93,14 @@
       "domain": "ai-agent-systems",
       "path": ".cursor/skills/ai-agent-systems/context-window-management/SKILL.md",
       "description": ">   Manage LLM context budgets—prioritization, summarization, compaction, and   what to load vs reference. Use for long sessions, large repos, or multi-doc tasks.   Triggers: \"context window\", \"too long\", \"summarize context\", \"token budget\".",
+      "summary": ">   Manage LLM context budgets—prioritization, summarization, compaction, and   what to load vs reference. Use for long sessions, large repos, or multi-doc tasks.   Triggers: \"context window\", \"too long\", \"summarize context\", \"token budget\"",
       "triggers": [
+        "context window",
+        "too long",
+        "summarize context",
+        "token budget"
+      ],
+      "trigger_phrases": [
         "context window",
         "too long",
         "summarize context",
@@ -82,7 +119,55 @@
         "rag",
         "tools",
         "context-window-management"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
+    },
+    {
+      "id": "ai-agent-systems/dispatching-parallel-agents",
+      "name": "dispatching-parallel-agents",
+      "domain": "ai-agent-systems",
+      "path": ".cursor/skills/ai-agent-systems/dispatching-parallel-agents/SKILL.md",
+      "description": ">   Split independent work across parallel agents with explicit boundaries and a   parent integration review. Use only when user allows subagents and tasks do not   share mutable files. Triggers: \"parallel agents\", \"fan out tasks\", \"run in parallel\".",
+      "summary": ">   Split independent work across parallel agents with explicit boundaries and a   parent integration review. Use only when user allows subagents and tasks do not   share mutable files. Triggers: \"parallel agents\", \"fan out tasks\", \"run in ",
+      "triggers": [
+        "parallel agents",
+        "fan out tasks",
+        "run in parallel"
+      ],
+      "trigger_phrases": [
+        "parallel agents",
+        "fan out tasks",
+        "run in parallel"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "agents",
+        "mcp",
+        "rag",
+        "tools",
+        "dispatching-parallel-agents"
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "ai-agent-systems/mcp-builder",
@@ -90,7 +175,14 @@
       "domain": "ai-agent-systems",
       "path": ".cursor/skills/ai-agent-systems/mcp-builder/SKILL.md",
       "description": ">   Design and implement MCP servers—tools, resources, prompts, schemas, and error   contracts for agent clients. Use when adding MCP integration or exposing   capabilities to Cursor/Claude agents.   Triggers: \"MCP server\", \"MCP tool\", \"Model Context Protocol\", \"build MCP\".",
+      "summary": ">   Design and implement MCP servers—tools, resources, prompts, schemas, and error   contracts for agent clients. Use when adding MCP integration or exposing   capabilities to Cursor/Claude agents.   Triggers: \"MCP server\", \"MCP tool\", \"Mod",
       "triggers": [
+        "MCP server",
+        "MCP tool",
+        "Model Context Protocol",
+        "build MCP"
+      ],
+      "trigger_phrases": [
         "MCP server",
         "MCP tool",
         "Model Context Protocol",
@@ -109,7 +201,15 @@
         "rag",
         "tools",
         "mcp-builder"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "ai-agent-systems/mcp-ecosystem-optimizer",
@@ -117,7 +217,15 @@
       "domain": "ai-agent-systems",
       "path": ".cursor/skills/ai-agent-systems/mcp-ecosystem-optimizer/SKILL.md",
       "description": "Review and optimize MCP server setup—inventory, registry hygiene, config, versioning, and observability. Use when managing multiple MCP servers in Cursor or Claude. Triggers: \"MCP server\", \"MCP config\", \"MCP registry\", \"optimize MCP\", \"too many MCP tools\".",
+      "summary": "Review and optimize MCP server setup—inventory, registry hygiene, config, versioning, and observability. Use when managing multiple MCP servers in Cursor or Claude. Triggers: \"MCP server\", \"MCP config\", \"MCP registry\", \"optimize MCP\", \"too ",
       "triggers": [
+        "MCP server",
+        "MCP config",
+        "MCP registry",
+        "optimize MCP",
+        "too many MCP tools"
+      ],
+      "trigger_phrases": [
         "MCP server",
         "MCP config",
         "MCP registry",
@@ -137,7 +245,15 @@
         "rag",
         "tools",
         "mcp-ecosystem-optimizer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "ai-agent-systems/rag-systems",
@@ -145,7 +261,15 @@
       "domain": "ai-agent-systems",
       "path": ".cursor/skills/ai-agent-systems/rag-systems/SKILL.md",
       "description": ">   Design retrieval-augmented generation pipelines—chunking, embeddings, retrieval,   reranking, grounding, and evaluation. Use when building or improving doc Q&A,   code search agents, or knowledge bases.   Triggers: \"RAG\", \"vector search\", \"embeddings\", \"retrieval\", \"knowledge base\".",
+      "summary": ">   Design retrieval-augmented generation pipelines—chunking, embeddings, retrieval,   reranking, grounding, and evaluation. Use when building or improving doc Q&A,   code search agents, or knowledge bases.   Triggers: \"RAG\", \"vector search",
       "triggers": [
+        "RAG",
+        "vector search",
+        "embeddings",
+        "retrieval",
+        "knowledge base"
+      ],
+      "trigger_phrases": [
         "RAG",
         "vector search",
         "embeddings",
@@ -165,7 +289,55 @@
         "rag",
         "tools",
         "rag-systems"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
+    },
+    {
+      "id": "ai-agent-systems/subagent-driven-development",
+      "name": "subagent-driven-development",
+      "domain": "ai-agent-systems",
+      "path": ".cursor/skills/ai-agent-systems/subagent-driven-development/SKILL.md",
+      "description": ">   Execute an approved plan via one subagent per task with spec and quality checks.   Use only when user allows subagents and a written plan exists. Triggers: \"subagent   per task\", \"dispatch implementer\", \"agent per plan step\".",
+      "summary": ">   Execute an approved plan via one subagent per task with spec and quality checks.   Use only when user allows subagents and a written plan exists. Triggers: \"subagent   per task\", \"dispatch implementer\", \"agent per plan step\".",
+      "triggers": [
+        "subagent   per task",
+        "dispatch implementer",
+        "agent per plan step"
+      ],
+      "trigger_phrases": [
+        "subagent   per task",
+        "dispatch implementer",
+        "agent per plan step"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "agents",
+        "mcp",
+        "rag",
+        "tools",
+        "subagent-driven-development"
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "analysis-stats/shap",
@@ -173,7 +345,9 @@
       "domain": "analysis-stats",
       "path": ".cursor/skills/analysis-stats/shap/SKILL.md",
       "description": "Model interpretability and explainability using SHAP (SHapley Additive exPlanations). Use this skill when explaining machine learning model predictions, computing feature importance, generating SHAP plots (waterfall, beeswarm, bar, scatter, force, heatmap), debugging models, analyzing model bias or fairness, comparing models, or implementing explainable AI. Works with tree-based models (XGBoost, LightGBM, Random Forest), deep learning (TensorFlow, PyTorch), linear models, and any black-box model",
+      "summary": "Model interpretability and explainability using SHAP (SHapley Additive exPlanations). Use this skill when explaining machine learning model predictions, computing feature importance, generating SHAP plots (waterfall, beeswarm, bar, scatter,",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -185,7 +359,15 @@
         "statistics",
         "shap",
         "modeling"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "analysis-stats/statistical-analysis",
@@ -193,7 +375,9 @@
       "domain": "analysis-stats",
       "path": ".cursor/skills/analysis-stats/statistical-analysis/SKILL.md",
       "description": "Guided statistical analysis with test selection and reporting. Use when you need help choosing appropriate tests for your data, assumption checking, power analysis, and APA-formatted results. Best for academic research reporting, test selection guidance. For implementing specific models programmatically use statsmodels.",
+      "summary": "Guided statistical analysis with test selection and reporting. Use when you need help choosing appropriate tests for your data, assumption checking, power analysis, and APA-formatted results. Best for academic research reporting, test selec",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -206,7 +390,15 @@
         "shap",
         "modeling",
         "statistical-analysis"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "analysis-stats/statsmodels",
@@ -214,7 +406,9 @@
       "domain": "analysis-stats",
       "path": ".cursor/skills/analysis-stats/statsmodels/SKILL.md",
       "description": "Statistical models library for Python. Use when you need specific model classes (OLS, GLM, mixed models, ARIMA) with detailed diagnostics, residuals, and inference. Best for econometrics, time series, rigorous inference with coefficient tables. For guided statistical test selection with APA reporting use statistical-analysis.",
+      "summary": "Statistical models library for Python. Use when you need specific model classes (OLS, GLM, mixed models, ARIMA) with detailed diagnostics, residuals, and inference. Best for econometrics, time series, rigorous inference with coefficient tab",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -227,7 +421,15 @@
         "shap",
         "modeling",
         "statsmodels"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "architecture/system-mapping",
@@ -235,7 +437,15 @@
       "domain": "architecture",
       "path": ".cursor/skills/architecture/system-mapping/SKILL.md",
       "description": "Map systems with diagrams—components, data flows, feedback loops, and causal relationships. Use for architecture understanding or stakeholder communication. Triggers: \"system map\", \"architecture diagram\", \"data flow\", \"C4\", \"how does this fit together\".",
+      "summary": "Map systems with diagrams—components, data flows, feedback loops, and causal relationships. Use for architecture understanding or stakeholder communication. Triggers: \"system map\", \"architecture diagram\", \"data flow\", \"C4\", \"how does this f",
       "triggers": [
+        "system map",
+        "architecture diagram",
+        "data flow",
+        "C4",
+        "how does this fit together"
+      ],
+      "trigger_phrases": [
         "system map",
         "architecture diagram",
         "data flow",
@@ -253,7 +463,15 @@
         "architecture",
         "diagrams",
         "system-mapping"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "core-workflow/api-and-interface-design",
@@ -261,7 +479,16 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/api-and-interface-design/SKILL.md",
       "description": "Design API and module boundaries with clear contracts, error semantics, pagination, and additive compatibility. Use before implementing REST/GraphQL endpoints, SDKs, or public module APIs. Triggers: \"API design\", \"interface contract\", \"endpoint design\", \"pagination\", \"error codes\", \"backward compatible\".",
+      "summary": "Design API and module boundaries with clear contracts, error semantics, pagination, and additive compatibility. Use before implementing REST/GraphQL endpoints, SDKs, or public module APIs. Triggers: \"API design\", \"interface contract\", \"endp",
       "triggers": [
+        "API design",
+        "interface contract",
+        "endpoint design",
+        "pagination",
+        "error codes",
+        "backward compatible"
+      ],
+      "trigger_phrases": [
         "API design",
         "interface contract",
         "endpoint design",
@@ -282,7 +509,15 @@
         "review",
         "testing",
         "api-and-interface-design"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/architecture-decision-records",
@@ -290,7 +525,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/architecture-decision-records/SKILL.md",
       "description": ">   Create and maintain Architecture Decision Records (ADRs) for significant technical   choices—frameworks, data stores, API shapes, ML platform decisions. Use when   documenting a decision, onboarding, or superseding a prior approach.   Triggers: \"ADR\", \"architecture decision\", \"document decision\", \"why we chose\".",
+      "summary": ">   Create and maintain Architecture Decision Records (ADRs) for significant technical   choices—frameworks, data stores, API shapes, ML platform decisions. Use when   documenting a decision, onboarding, or superseding a prior approach.   T",
       "triggers": [
+        "ADR",
+        "architecture decision",
+        "document decision",
+        "why we chose"
+      ],
+      "trigger_phrases": [
         "ADR",
         "architecture decision",
         "document decision",
@@ -309,7 +551,15 @@
         "review",
         "testing",
         "architecture-decision-records"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/clarify-underspecified",
@@ -317,7 +567,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/clarify-underspecified/SKILL.md",
       "description": ">   Ask the minimum clarifying questions before implementing when scope, constraints,   or success criteria are unclear. Use when a request has multiple plausible   interpretations, missing acceptance criteria, or ambiguous environment constraints.   Triggers: \"unclear\", \"ambiguous\", \"not sure what you want\", \"multiple options\".",
+      "summary": ">   Ask the minimum clarifying questions before implementing when scope, constraints,   or success criteria are unclear. Use when a request has multiple plausible   interpretations, missing acceptance criteria, or ambiguous environment cons",
       "triggers": [
+        "unclear",
+        "ambiguous",
+        "not sure what you want",
+        "multiple options"
+      ],
+      "trigger_phrases": [
         "unclear",
         "ambiguous",
         "not sure what you want",
@@ -336,7 +593,15 @@
         "review",
         "testing",
         "clarify-underspecified"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/code-simplification",
@@ -344,7 +609,15 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/code-simplification/SKILL.md",
       "description": "Simplify working code while preserving behavior—remove dead paths, flatten nesting, clarify names, reduce duplication. Use after features work but code feels over-engineered. Triggers: \"simplify\", \"clean up\", \"too complex\", \"YAGNI\", \"reduce complexity\".",
+      "summary": "Simplify working code while preserving behavior—remove dead paths, flatten nesting, clarify names, reduce duplication. Use after features work but code feels over-engineered. Triggers: \"simplify\", \"clean up\", \"too complex\", \"YAGNI\", \"reduce",
       "triggers": [
+        "simplify",
+        "clean up",
+        "too complex",
+        "YAGNI",
+        "reduce complexity"
+      ],
+      "trigger_phrases": [
         "simplify",
         "clean up",
         "too complex",
@@ -364,7 +637,15 @@
         "review",
         "testing",
         "code-simplification"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/deprecation-and-migration",
@@ -372,7 +653,15 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/deprecation-and-migration/SKILL.md",
       "description": ">   Plan deprecation and migration—replacement first, consumer migration, strangler   and adapter patterns, zombie code removal. Use when sunsetting APIs, libraries,   or legacy modules.   Triggers: \"deprecate\", \"migration plan\", \"sunset\", \"remove legacy\", \"strangler\".",
+      "summary": ">   Plan deprecation and migration—replacement first, consumer migration, strangler   and adapter patterns, zombie code removal. Use when sunsetting APIs, libraries,   or legacy modules.   Triggers: \"deprecate\", \"migration plan\", \"sunset\", ",
       "triggers": [
+        "deprecate",
+        "migration plan",
+        "sunset",
+        "remove legacy",
+        "strangler"
+      ],
+      "trigger_phrases": [
         "deprecate",
         "migration plan",
         "sunset",
@@ -392,7 +681,15 @@
         "review",
         "testing",
         "deprecation-and-migration"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/design-smell-review",
@@ -400,7 +697,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/design-smell-review/SKILL.md",
       "description": ">   Lightweight design smell review for modules and APIs—coupling, cohesion,   naming, boundaries, and unnecessary complexity. Use before large refactors or   when code feels hard to change. Complements gstack/review (diff-focused).   Triggers: \"design review\", \"code smell\", \"too complex\", \"refactor structure\".",
+      "summary": ">   Lightweight design smell review for modules and APIs—coupling, cohesion,   naming, boundaries, and unnecessary complexity. Use before large refactors or   when code feels hard to change. Complements gstack/review (diff-focused).   Trigg",
       "triggers": [
+        "design review",
+        "code smell",
+        "too complex",
+        "refactor structure"
+      ],
+      "trigger_phrases": [
         "design review",
         "code smell",
         "too complex",
@@ -419,7 +723,15 @@
         "review",
         "testing",
         "design-smell-review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/doubt-driven-review",
@@ -427,7 +739,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/doubt-driven-review/SKILL.md",
       "description": ">   Adversarial fresh-context review for non-trivial decisions before they stand.   Use for production-impacting logic, security-sensitive changes, unfamiliar code,   or high-blast-radius architecture choices.   Triggers: \"doubt check\", \"adversarial review\", \"challenge this decision\", \"second look\".",
+      "summary": ">   Adversarial fresh-context review for non-trivial decisions before they stand.   Use for production-impacting logic, security-sensitive changes, unfamiliar code,   or high-blast-radius architecture choices.   Triggers: \"doubt check\", \"ad",
       "triggers": [
+        "doubt check",
+        "adversarial review",
+        "challenge this decision",
+        "second look"
+      ],
+      "trigger_phrases": [
         "doubt check",
         "adversarial review",
         "challenge this decision",
@@ -446,7 +765,15 @@
         "review",
         "testing",
         "doubt-driven-review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/github-comment-triage",
@@ -454,7 +781,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/github-comment-triage/SKILL.md",
       "description": ">   Triage and address GitHub PR review comments systematically—classify, respond,   fix or defer with rationale. Use when a PR has review feedback, requested changes,   or unresolved threads.   Triggers: \"PR comments\", \"review feedback\", \"address comments\", \"requested changes\".",
+      "summary": ">   Triage and address GitHub PR review comments systematically—classify, respond,   fix or defer with rationale. Use when a PR has review feedback, requested changes,   or unresolved threads.   Triggers: \"PR comments\", \"review feedback\", \"",
       "triggers": [
+        "PR comments",
+        "review feedback",
+        "address comments",
+        "requested changes"
+      ],
+      "trigger_phrases": [
         "PR comments",
         "review feedback",
         "address comments",
@@ -473,7 +807,15 @@
         "review",
         "testing",
         "github-comment-triage"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/idea-refine",
@@ -481,7 +823,15 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/idea-refine/SKILL.md",
       "description": "Shape early ideas through divergent exploration and convergent narrowing before specs or builds. Use when brainstorming product features, model approaches, or architecture directions. Triggers: \"refine this idea\", \"brainstorm\", \"explore options\", \"which direction\", \"not sure yet\".",
+      "summary": "Shape early ideas through divergent exploration and convergent narrowing before specs or builds. Use when brainstorming product features, model approaches, or architecture directions. Triggers: \"refine this idea\", \"brainstorm\", \"explore opt",
       "triggers": [
+        "refine this idea",
+        "brainstorm",
+        "explore options",
+        "which direction",
+        "not sure yet"
+      ],
+      "trigger_phrases": [
         "refine this idea",
         "brainstorm",
         "explore options",
@@ -501,7 +851,15 @@
         "review",
         "testing",
         "idea-refine"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/incremental-implementation",
@@ -509,7 +867,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/incremental-implementation/SKILL.md",
       "description": ">   Implement multi-file changes in thin vertical slices—implement, test, verify,   commit. Use when a feature touches more than one file or feels too large for one pass.   Triggers: \"incremental\", \"vertical slice\", \"one step at a time\", \"small commits\".",
+      "summary": ">   Implement multi-file changes in thin vertical slices—implement, test, verify,   commit. Use when a feature touches more than one file or feels too large for one pass.   Triggers: \"incremental\", \"vertical slice\", \"one step at a time\", \"s",
       "triggers": [
+        "incremental",
+        "vertical slice",
+        "one step at a time",
+        "small commits"
+      ],
+      "trigger_phrases": [
         "incremental",
         "vertical slice",
         "one step at a time",
@@ -528,7 +893,15 @@
         "review",
         "testing",
         "incremental-implementation"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/interview-me",
@@ -536,7 +909,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/interview-me/SKILL.md",
       "description": "Extract user intent through structured one-question-at-a-time interviews before specs or implementation. Use when requirements are fuzzy, the user says \"help me think through\", or you need success criteria before planning. Triggers: \"interview me\", \"ask me questions\", \"clarify intent\", \"what do you need to know\".",
+      "summary": "Extract user intent through structured one-question-at-a-time interviews before specs or implementation. Use when requirements are fuzzy, the user says \"help me think through\", or you need success criteria before planning. Triggers: \"interv",
       "triggers": [
+        "interview me",
+        "ask me questions",
+        "clarify intent",
+        "what do you need to know"
+      ],
+      "trigger_phrases": [
         "interview me",
         "ask me questions",
         "clarify intent",
@@ -555,7 +935,15 @@
         "review",
         "testing",
         "interview-me"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/planning-and-task-breakdown",
@@ -563,7 +951,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/planning-and-task-breakdown/SKILL.md",
       "description": ">   Decompose specs into small, ordered tasks with acceptance criteria and verification   steps. Use when you have requirements and need an implementable plan or task list.   Triggers: \"break down tasks\", \"implementation plan\", \"task breakdown\", \"plan mode\".",
+      "summary": ">   Decompose specs into small, ordered tasks with acceptance criteria and verification   steps. Use when you have requirements and need an implementable plan or task list.   Triggers: \"break down tasks\", \"implementation plan\", \"task breakd",
       "triggers": [
+        "break down tasks",
+        "implementation plan",
+        "task breakdown",
+        "plan mode"
+      ],
+      "trigger_phrases": [
         "break down tasks",
         "implementation plan",
         "task breakdown",
@@ -582,7 +977,15 @@
         "review",
         "testing",
         "planning-and-task-breakdown"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/receiving-code-review",
@@ -590,7 +993,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/receiving-code-review/SKILL.md",
       "description": ">   Receive code review feedback constructively—verify claims, prioritize fixes,   push back with evidence when needed. Use when acting on reviewer comments or   preparing a second review round.   Triggers: \"code review\", \"reviewer said\", \"address review\", \"feedback on PR\".",
+      "summary": ">   Receive code review feedback constructively—verify claims, prioritize fixes,   push back with evidence when needed. Use when acting on reviewer comments or   preparing a second review round.   Triggers: \"code review\", \"reviewer said\", \"",
       "triggers": [
+        "code review",
+        "reviewer said",
+        "address review",
+        "feedback on PR"
+      ],
+      "trigger_phrases": [
         "code review",
         "reviewer said",
         "address review",
@@ -609,7 +1019,57 @@
         "review",
         "testing",
         "receiving-code-review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
+    },
+    {
+      "id": "core-workflow/requesting-code-review",
+      "name": "requesting-code-review",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/requesting-code-review/SKILL.md",
+      "description": ">   Request a focused code review with scope, diff context, and severity-ordered   findings. Use before merge or between plan tasks when quality gate is needed.   Triggers: \"request review\", \"review my diff\", \"pre-merge review\", \"second pair of eyes\".",
+      "summary": ">   Request a focused code review with scope, diff context, and severity-ordered   findings. Use before merge or between plan tasks when quality gate is needed.   Triggers: \"request review\", \"review my diff\", \"pre-merge review\", \"second pai",
+      "triggers": [
+        "request review",
+        "review my diff",
+        "pre-merge review",
+        "second pair of eyes"
+      ],
+      "trigger_phrases": [
+        "request review",
+        "review my diff",
+        "pre-merge review",
+        "second pair of eyes"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "requesting-code-review"
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/source-driven-development",
@@ -617,7 +1077,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/source-driven-development/SKILL.md",
       "description": ">   Ground framework and library decisions in official documentation—detect versions,   fetch relevant docs, cite sources, flag unverified patterns. Use when API correctness   matters for React, Next.js, Python libs, cloud SDKs, or unfamiliar stacks.   Triggers: \"official docs\", \"verify API\", \"source-driven\", \"is this API still valid\".",
+      "summary": ">   Ground framework and library decisions in official documentation—detect versions,   fetch relevant docs, cite sources, flag unverified patterns. Use when API correctness   matters for React, Next.js, Python libs, cloud SDKs, or unfamili",
       "triggers": [
+        "official docs",
+        "verify API",
+        "source-driven",
+        "is this API still valid"
+      ],
+      "trigger_phrases": [
         "official docs",
         "verify API",
         "source-driven",
@@ -636,7 +1103,15 @@
         "review",
         "testing",
         "source-driven-development"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/spec-driven-development",
@@ -644,7 +1119,15 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/spec-driven-development/SKILL.md",
       "description": ">   Write a structured spec before significant implementation—objective, commands,   boundaries, testing, and success criteria. Use when starting a feature, project,   or multi-file change without a written spec.   Triggers: \"write spec\", \"PRD\", \"requirements\", \"spec before code\", \"what are we building\".",
+      "summary": ">   Write a structured spec before significant implementation—objective, commands,   boundaries, testing, and success criteria. Use when starting a feature, project,   or multi-file change without a written spec.   Triggers: \"write spec\", \"",
       "triggers": [
+        "write spec",
+        "PRD",
+        "requirements",
+        "spec before code",
+        "what are we building"
+      ],
+      "trigger_phrases": [
         "write spec",
         "PRD",
         "requirements",
@@ -664,7 +1147,57 @@
         "review",
         "testing",
         "spec-driven-development"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
+    },
+    {
+      "id": "core-workflow/systematic-debugging",
+      "name": "systematic-debugging",
+      "domain": "core-workflow",
+      "path": ".cursor/skills/core-workflow/systematic-debugging/SKILL.md",
+      "description": ">   Four-phase root-cause debugging—reproduce, compare patterns, hypothesize, fix with   tests. Use when errors are unclear, fixes failed twice, or symptoms keep returning.   Triggers: \"root cause\", \"debug systematically\", \"why is this broken\", \"still failing\".",
+      "summary": ">   Four-phase root-cause debugging—reproduce, compare patterns, hypothesize, fix with   tests. Use when errors are unclear, fixes failed twice, or symptoms keep returning.   Triggers: \"root cause\", \"debug systematically\", \"why is this brok",
+      "triggers": [
+        "root cause",
+        "debug systematically",
+        "why is this broken",
+        "still failing"
+      ],
+      "trigger_phrases": [
+        "root cause",
+        "debug systematically",
+        "why is this broken",
+        "still failing"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "workflow",
+        "planning",
+        "review",
+        "testing",
+        "systematic-debugging"
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/test-failure-triage",
@@ -672,7 +1205,14 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/test-failure-triage/SKILL.md",
       "description": ">   Systematically triage failing tests by grouping errors, fixing root causes in   priority order, and verifying incrementally. Use when CI fails, test suite is   broken, or multiple tests fail after a refactor or merge.   Triggers: \"tests failing\", \"fix tests\", \"CI red\", \"make tests pass\".",
+      "summary": ">   Systematically triage failing tests by grouping errors, fixing root causes in   priority order, and verifying incrementally. Use when CI fails, test suite is   broken, or multiple tests fail after a refactor or merge.   Triggers: \"tests",
       "triggers": [
+        "tests failing",
+        "fix tests",
+        "CI red",
+        "make tests pass"
+      ],
+      "trigger_phrases": [
         "tests failing",
         "fix tests",
         "CI red",
@@ -691,7 +1231,15 @@
         "review",
         "testing",
         "test-failure-triage"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/test-first-development",
@@ -699,7 +1247,15 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/test-first-development/SKILL.md",
       "description": ">   Apply test-first discipline for behavior changes and bugfixes: define expected   behavior, add or run a failing test, then implement minimally. Use when fixing   bugs, changing logic, or adding features that need regression protection.   Triggers: \"bugfix\", \"TDD\", \"regression test\", \"behavior change\", \"add test\".",
+      "summary": ">   Apply test-first discipline for behavior changes and bugfixes: define expected   behavior, add or run a failing test, then implement minimally. Use when fixing   bugs, changing logic, or adding features that need regression protection. ",
       "triggers": [
+        "bugfix",
+        "TDD",
+        "regression test",
+        "behavior change",
+        "add test"
+      ],
+      "trigger_phrases": [
         "bugfix",
         "TDD",
         "regression test",
@@ -719,7 +1275,15 @@
         "review",
         "testing",
         "test-first-development"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/verify-before-done",
@@ -727,7 +1291,15 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/verify-before-done/SKILL.md",
       "description": ">   Require fresh verification evidence before claiming tests pass, builds succeed,   or work is complete. Use when finishing a task, creating a PR, or reporting status.   Triggers: \"done\", \"fixed\", \"passes\", \"ready to merge\", \"all tests green\".",
+      "summary": ">   Require fresh verification evidence before claiming tests pass, builds succeed,   or work is complete. Use when finishing a task, creating a PR, or reporting status.   Triggers: \"done\", \"fixed\", \"passes\", \"ready to merge\", \"all tests gr",
       "triggers": [
+        "done",
+        "fixed",
+        "passes",
+        "ready to merge",
+        "all tests green"
+      ],
+      "trigger_phrases": [
         "done",
         "fixed",
         "passes",
@@ -747,7 +1319,15 @@
         "review",
         "testing",
         "verify-before-done"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "core-workflow/work-access-handoff",
@@ -755,7 +1335,15 @@
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/work-access-handoff/SKILL.md",
       "description": "Explain and document work access layers—repo permissions, local vs cloud environments, handoff packages for collaborators. Triggers: \"handoff\", \"access\", \"onboard collaborator\", \"share project\", \"where is the work\".",
+      "summary": "Explain and document work access layers—repo permissions, local vs cloud environments, handoff packages for collaborators. Triggers: \"handoff\", \"access\", \"onboard collaborator\", \"share project\", \"where is the work\".",
       "triggers": [
+        "handoff",
+        "access",
+        "onboard collaborator",
+        "share project",
+        "where is the work"
+      ],
+      "trigger_phrases": [
         "handoff",
         "access",
         "onboard collaborator",
@@ -775,7 +1363,15 @@
         "review",
         "testing",
         "work-access-handoff"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "data-compute/dask",
@@ -783,7 +1379,9 @@
       "domain": "data-compute",
       "path": ".cursor/skills/data-compute/dask/SKILL.md",
       "description": "Distributed computing for larger-than-RAM pandas/NumPy workflows. Use when you need to scale existing pandas/NumPy code beyond memory or across clusters. Best for parallel file processing, distributed ML, integration with existing pandas code. For out-of-core analytics on single machine use vaex; for in-memory speed use polars.",
+      "summary": "Distributed computing for larger-than-RAM pandas/NumPy workflows. Use when you need to scale existing pandas/NumPy code beyond memory or across clusters. Best for parallel file processing, distributed ML, integration with existing pandas co",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -796,7 +1394,15 @@
         "etl",
         "compute",
         "dask"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "data-compute/networkx",
@@ -804,7 +1410,9 @@
       "domain": "data-compute",
       "path": ".cursor/skills/data-compute/networkx/SKILL.md",
       "description": "Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths, centrality, clustering), detecting communities, generating synthetic networks, or visualizing network topologies. Applicable to social networks, biological networks, transportation systems, citation networks, and any domain involving pairwise relationships.",
+      "summary": "Comprehensive toolkit for creating, analyzing, and visualizing complex networks and graphs in Python. Use when working with network/graph data structures, analyzing relationships between entities, computing graph algorithms (shortest paths,",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -817,7 +1425,15 @@
         "etl",
         "compute",
         "networkx"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "data-compute/polars",
@@ -825,7 +1441,9 @@
       "domain": "data-compute",
       "path": ".cursor/skills/data-compute/polars/SKILL.md",
       "description": "Fast in-memory DataFrame library for datasets that fit in RAM. Use when pandas is too slow but data still fits in memory. Lazy evaluation, parallel execution, Apache Arrow backend. Best for 1-100GB datasets, ETL pipelines, faster pandas replacement. For larger-than-RAM data use dask or vaex.",
+      "summary": "Fast in-memory DataFrame library for datasets that fit in RAM. Use when pandas is too slow but data still fits in memory. Lazy evaluation, parallel execution, Apache Arrow backend. Best for 1-100GB datasets, ETL pipelines, faster pandas rep",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -838,7 +1456,15 @@
         "etl",
         "compute",
         "polars"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "eda-research/exploratory-data-analysis",
@@ -846,7 +1472,9 @@
       "domain": "eda-research",
       "path": ".cursor/skills/eda-research/exploratory-data-analysis/SKILL.md",
       "description": "Perform comprehensive exploratory data analysis on scientific data files across 200+ file formats. This skill should be used when analyzing any scientific data file to understand its structure, content, quality, and characteristics. Automatically detects file type and generates detailed markdown reports with format-specific analysis, quality metrics, and downstream analysis recommendations. Covers chemistry, bioinformatics, microscopy, spectroscopy, proteomics, metabolomics, and general scientif",
+      "summary": "Perform comprehensive exploratory data analysis on scientific data files across 200+ file formats. This skill should be used when analyzing any scientific data file to understand its structure, content, quality, and characteristics. Automat",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -858,7 +1486,15 @@
         "eda",
         "research",
         "exploratory-data-analysis"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "eda-research/hypothesis-generation",
@@ -866,7 +1502,9 @@
       "domain": "eda-research",
       "path": ".cursor/skills/eda-research/hypothesis-generation/SKILL.md",
       "description": "Structured hypothesis formulation from observations. Use when you have experimental observations or data and need to formulate testable hypotheses with predictions, propose mechanisms, and design experiments to test them. Follows scientific method framework. For open-ended ideation use scientific-brainstorming; for automated LLM-driven hypothesis testing on datasets use hypogenic.",
+      "summary": "Structured hypothesis formulation from observations. Use when you have experimental observations or data and need to formulate testable hypotheses with predictions, propose mechanisms, and design experiments to test them. Follows scientific",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -878,7 +1516,15 @@
         "eda",
         "research",
         "hypothesis-generation"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "eda-research/umap-learn",
@@ -886,7 +1532,9 @@
       "domain": "eda-research",
       "path": ".cursor/skills/eda-research/umap-learn/SKILL.md",
       "description": "UMAP dimensionality reduction. Fast nonlinear manifold learning for 2D/3D visualization, clustering preprocessing (HDBSCAN), supervised/parametric UMAP, for high-dimensional data.",
+      "summary": "UMAP dimensionality reduction. Fast nonlinear manifold learning for 2D/3D visualization, clustering preprocessing (HDBSCAN), supervised/parametric UMAP, for high-dimensional data.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -898,7 +1546,15 @@
         "eda",
         "research",
         "umap-learn"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "frontend-engineering/browser-testing-with-devtools",
@@ -906,7 +1562,16 @@
       "domain": "frontend-engineering",
       "path": ".cursor/skills/frontend-engineering/browser-testing-with-devtools/SKILL.md",
       "description": "Verify web apps with browser DevTools—DOM, console, network, performance, and accessibility at runtime. Use with Chrome DevTools MCP or headless browser tools. Triggers: \"DevTools\", \"browser test\", \"console errors\", \"network tab\", \"Lighthouse\", \"runtime check\".",
+      "summary": "Verify web apps with browser DevTools—DOM, console, network, performance, and accessibility at runtime. Use with Chrome DevTools MCP or headless browser tools. Triggers: \"DevTools\", \"browser test\", \"console errors\", \"network tab\", \"Lighthou",
       "triggers": [
+        "DevTools",
+        "browser test",
+        "console errors",
+        "network tab",
+        "Lighthouse",
+        "runtime check"
+      ],
+      "trigger_phrases": [
         "DevTools",
         "browser test",
         "console errors",
@@ -926,7 +1591,15 @@
         "ui",
         "browser",
         "browser-testing-with-devtools"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "frontend-engineering/frontend-ui-accessibility",
@@ -934,7 +1607,15 @@
       "domain": "frontend-engineering",
       "path": ".cursor/skills/frontend-engineering/frontend-ui-accessibility/SKILL.md",
       "description": ">   Build accessible UI—semantic HTML, keyboard support, ARIA when needed, WCAG-oriented   checks. Use when implementing or reviewing web UI, forms, modals, and design systems.   Triggers: \"accessibility\", \"a11y\", \"WCAG\", \"keyboard nav\", \"screen reader\".",
+      "summary": ">   Build accessible UI—semantic HTML, keyboard support, ARIA when needed, WCAG-oriented   checks. Use when implementing or reviewing web UI, forms, modals, and design systems.   Triggers: \"accessibility\", \"a11y\", \"WCAG\", \"keyboard nav\", \"s",
       "triggers": [
+        "accessibility",
+        "a11y",
+        "WCAG",
+        "keyboard nav",
+        "screen reader"
+      ],
+      "trigger_phrases": [
         "accessibility",
         "a11y",
         "WCAG",
@@ -953,7 +1634,15 @@
         "ui",
         "browser",
         "frontend-ui-accessibility"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "frontend-engineering/frontend-ui-engineering",
@@ -961,7 +1650,16 @@
       "domain": "frontend-engineering",
       "path": ".cursor/skills/frontend-engineering/frontend-ui-engineering/SKILL.md",
       "description": "Build and refine web UI—component structure, responsive layout, design tokens, state, and accessibility. Use for feature UI work beyond WCAG checks alone. Triggers: \"build UI\", \"component\", \"responsive\", \"design system\", \"frontend\", \"layout\".",
+      "summary": "Build and refine web UI—component structure, responsive layout, design tokens, state, and accessibility. Use for feature UI work beyond WCAG checks alone. Triggers: \"build UI\", \"component\", \"responsive\", \"design system\", \"frontend\", \"layout",
       "triggers": [
+        "build UI",
+        "component",
+        "responsive",
+        "design system",
+        "frontend",
+        "layout"
+      ],
+      "trigger_phrases": [
         "build UI",
         "component",
         "responsive",
@@ -981,7 +1679,15 @@
         "ui",
         "browser",
         "frontend-ui-engineering"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "gstack",
@@ -989,7 +1695,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/SKILL.md",
       "description": "Fast headless browser for QA testing and site dogfooding. Navigate pages,   interact with elements, verify state, diff before/after, take annotated screenshots,   test responsive layouts, forms, uploads, dialogs, and capture bug evidence. Use   when asked to open or test a site, verify a deployment, dogfood a user flow, or   file a bug with screenshots. (gstack)",
+      "summary": "Fast headless browser for QA testing and site dogfooding. Navigate pages,   interact with elements, verify state, diff before/after, take annotated screenshots,   test responsive layouts, forms, uploads, dialogs, and capture bug evidence. U",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1002,7 +1710,15 @@
         "ship",
         "browser",
         "gstack"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/browser-qa/benchmark",
@@ -1010,7 +1726,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/browser-qa/benchmark/SKILL.md",
       "description": "Performance regression detection using the browse daemon. Establishes   baselines for page load times, Core Web Vitals, and resource sizes. Compares before/after   on every PR. Tracks performance trends over time. Use when: \"performance\", \"benchmark\",   \"page speed\", \"lighthouse\", \"web vitals\", \"bundle size\", \"load time\". (gstack) Voice   triggers (speech-to-text aliases): \"speed test\", \"check performance\".",
+      "summary": "Performance regression detection using the browse daemon. Establishes   baselines for page load times, Core Web Vitals, and resource sizes. Compares before/after   on every PR. Tracks performance trends over time. Use when: \"performance\", \"",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1024,7 +1742,15 @@
         "browser",
         "gstack",
         "benchmark"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/browser-qa/benchmark-models",
@@ -1032,7 +1758,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/browser-qa/benchmark-models/SKILL.md",
       "description": "Cross-model benchmark for gstack skills. Runs the same prompt through   Claude, GPT (via Codex CLI), and Gemini side-by-side — compares latency, tokens,   cost, and optionally quality via LLM judge. Answers \"which model is actually best   for this skill?\" with data instead of vibes. Separate from /benchmark, which measures   web page performance. Use when: \"benchmark models\", \"compare models\", \"which model   is best for X\", \"cross-model comparison\", \"model shootout\". (gstack) Voice triggers   (s",
+      "summary": "Cross-model benchmark for gstack skills. Runs the same prompt through   Claude, GPT (via Codex CLI), and Gemini side-by-side — compares latency, tokens,   cost, and optionally quality via LLM judge. Answers \"which model is actually best   f",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1046,7 +1774,15 @@
         "browser",
         "gstack",
         "benchmark-models"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/browser-qa/browse",
@@ -1054,7 +1790,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/browser-qa/browse/SKILL.md",
       "description": "Fast headless browser for QA testing and site dogfooding. Navigate any   URL, interact with elements, verify page state, diff before/after actions, take   annotated screenshots, check responsive layouts, test forms and uploads, handle   dialogs, and assert element states. ~100ms per command. Use when you need to test   a feature, verify a deployment, dogfood a user flow, or file a bug with evidence.   Use when asked to \"open in browser\", \"test the site\", \"take a screenshot\", or \"dogfood   this\".",
+      "summary": "Fast headless browser for QA testing and site dogfooding. Navigate any   URL, interact with elements, verify page state, diff before/after actions, take   annotated screenshots, check responsive layouts, test forms and uploads, handle   dia",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1068,7 +1806,15 @@
         "browser",
         "gstack",
         "browse"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/browser-qa/canary",
@@ -1076,7 +1822,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/browser-qa/canary/SKILL.md",
       "description": "Post-deploy canary monitoring. Watches the live app for console errors,   performance regressions, and page failures using the browse daemon. Takes periodic   screenshots, compares against pre-deploy baselines, and alerts on anomalies. Use   when: \"monitor deploy\", \"canary\", \"post-deploy check\", \"watch production\", \"verify   deploy\". (gstack)",
+      "summary": "Post-deploy canary monitoring. Watches the live app for console errors,   performance regressions, and page failures using the browse daemon. Takes periodic   screenshots, compares against pre-deploy baselines, and alerts on anomalies. Use ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1090,7 +1838,15 @@
         "browser",
         "gstack",
         "canary"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/browser-qa/qa",
@@ -1098,7 +1854,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/browser-qa/qa/SKILL.md",
       "description": "Systematically QA test a web application and fix bugs found. Runs QA   testing, then iteratively fixes bugs in source code, committing each fix atomically   and re-verifying. Use when asked to \"qa\", \"QA\", \"test this site\", \"find bugs\", \"test   and fix\", or \"fix what''s broken\". Proactively suggest when the user says a feature   is ready for testing or asks \"does this work?\". Three tiers: Quick (critical/high   only), Standard (+ medium), Exhaustive (+ cosmetic). Produces before/after health   sc",
+      "summary": "Systematically QA test a web application and fix bugs found. Runs QA   testing, then iteratively fixes bugs in source code, committing each fix atomically   and re-verifying. Use when asked to \"qa\", \"QA\", \"test this site\", \"find bugs\", \"tes",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1111,7 +1869,15 @@
         "ship",
         "browser",
         "gstack"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/browser-qa/qa-only",
@@ -1119,7 +1885,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/browser-qa/qa-only/SKILL.md",
       "description": "Report-only QA testing. Systematically tests a web application and produces   a structured report with health score, screenshots, and repro steps — but never   fixes anything. Use when asked to \"just report bugs\", \"qa report only\", or \"test   but don''t fix\". For the full test-fix-verify loop, use /qa instead. Proactively   suggest when the user wants a bug report without any code changes. (gstack) Voice   triggers (speech-to-text aliases): \"bug report\", \"just check for bugs\".",
+      "summary": "Report-only QA testing. Systematically tests a web application and produces   a structured report with health score, screenshots, and repro steps — but never   fixes anything. Use when asked to \"just report bugs\", \"qa report only\", or \"test",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1133,7 +1901,15 @@
         "browser",
         "gstack",
         "qa-only"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/code-quality/codex",
@@ -1141,7 +1917,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/code-quality/codex/SKILL.md",
       "description": "OpenAI Codex CLI wrapper — three modes. Code review: independent diff   review via codex review with pass/fail gate. Challenge: adversarial mode that tries   to break your code. Consult: ask codex anything with session continuity for follow-ups.   The \"200 IQ autistic developer\" second opinion. Use when asked to \"codex review\",   \"codex challenge\", \"ask codex\", \"second opinion\", or \"consult codex\". (gstack) Voice   triggers (speech-to-text aliases): \"code x\", \"code ex\", \"get another opinion\".",
+      "summary": "OpenAI Codex CLI wrapper — three modes. Code review: independent diff   review via codex review with pass/fail gate. Challenge: adversarial mode that tries   to break your code. Consult: ask codex anything with session continuity for follow",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1155,7 +1933,15 @@
         "browser",
         "gstack",
         "codex"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/code-quality/health",
@@ -1163,7 +1949,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/code-quality/health/SKILL.md",
       "description": "Code quality dashboard. Wraps existing project tools (type checker,   linter, test runner, dead code detector, shell linter), computes a weighted composite   0-10 score, and tracks trends over time. Use when: \"health check\", \"code quality\",   \"how healthy is the codebase\", \"run all checks\", \"quality score\". (gstack)",
+      "summary": "Code quality dashboard. Wraps existing project tools (type checker,   linter, test runner, dead code detector, shell linter), computes a weighted composite   0-10 score, and tracks trends over time. Use when: \"health check\", \"code quality\",",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1177,7 +1965,15 @@
         "browser",
         "gstack",
         "health"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/code-quality/investigate",
@@ -1185,7 +1981,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/code-quality/investigate/SKILL.md",
       "description": "Systematic debugging with root cause investigation. Four phases: investigate,   analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when   asked to \"debug this\", \"fix this bug\", \"why is this broken\", \"investigate this error\",   or \"root cause analysis\". Proactively invoke this skill (do NOT debug directly)   when the user reports errors, 500 errors, stack traces, unexpected behavior, \"it   was working yesterday\", or is troubleshooting why something stopped working. (gstac",
+      "summary": "Systematic debugging with root cause investigation. Four phases: investigate,   analyze, hypothesize, implement. Iron Law: no fixes without root cause. Use when   asked to \"debug this\", \"fix this bug\", \"why is this broken\", \"investigate thi",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1199,7 +1997,15 @@
         "browser",
         "gstack",
         "investigate"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/code-quality/review",
@@ -1207,7 +2013,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/code-quality/review/SKILL.md",
       "description": "Pre-landing PR review. Analyzes diff against the base branch for SQL   safety, LLM trust boundary violations, conditional side effects, and other structural   issues. Use when asked to \"review this PR\", \"code review\", \"pre-landing review\",   or \"check my diff\". Proactively suggest when the user is about to merge or land   code changes. (gstack)",
+      "summary": "Pre-landing PR review. Analyzes diff against the base branch for SQL   safety, LLM trust boundary violations, conditional side effects, and other structural   issues. Use when asked to \"review this PR\", \"code review\", \"pre-landing review\", ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1221,7 +2029,15 @@
         "browser",
         "gstack",
         "review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/context-memory/context-restore",
@@ -1229,7 +2045,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/context-memory/context-restore/SKILL.md",
       "description": "Restore working context saved earlier by /context-save. Loads the most   recent saved state (across all branches by default) so you can pick up where you   left off — even across Conductor workspace handoffs. Use when asked to \"resume\",   \"restore context\", \"where was I\", or \"pick up where I left off\". Pair with /context-save.   Formerly /checkpoint resume — renamed because Claude Code treats /checkpoint as   a native rewind alias in current environments. (gstack)",
+      "summary": "Restore working context saved earlier by /context-save. Loads the most   recent saved state (across all branches by default) so you can pick up where you   left off — even across Conductor workspace handoffs. Use when asked to \"resume\",   \"",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1243,7 +2061,15 @@
         "browser",
         "gstack",
         "context-restore"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/context-memory/context-save",
@@ -1251,7 +2077,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/context-memory/context-save/SKILL.md",
       "description": "Save working context. Captures git state, decisions made, and remaining   work so any future session can pick up without losing a beat. Use when asked to   \"save progress\", \"save state\", \"context save\", or \"save my work\". Pair with /context-restore   to resume later. Formerly /checkpoint — renamed because Claude Code treats /checkpoint   as a native rewind alias in current environments, which was shadowing this skill.   (gstack)",
+      "summary": "Save working context. Captures git state, decisions made, and remaining   work so any future session can pick up without losing a beat. Use when asked to   \"save progress\", \"save state\", \"context save\", or \"save my work\". Pair with /context",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1265,7 +2093,15 @@
         "browser",
         "gstack",
         "context-save"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/context-memory/learn",
@@ -1273,7 +2109,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/context-memory/learn/SKILL.md",
       "description": "Manage project learnings. Review, search, prune, and export what gstack   has learned across sessions. Use when asked to \"what have we learned\", \"show learnings\",   \"prune stale learnings\", or \"export learnings\". Proactively suggest when the user   asks about past patterns or wonders \"didn't we fix this before?",
+      "summary": "Manage project learnings. Review, search, prune, and export what gstack   has learned across sessions. Use when asked to \"what have we learned\", \"show learnings\",   \"prune stale learnings\", or \"export learnings\". Proactively suggest when th",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1287,7 +2125,15 @@
         "browser",
         "gstack",
         "learn"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/context-memory/setup-gbrain",
@@ -1295,7 +2141,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/context-memory/setup-gbrain/SKILL.md",
       "description": "Set up gbrain for this coding agent: install the CLI, initialize a local   PGLite or Supabase brain, register MCP, capture per-remote trust policy. One command   from zero to \"gbrain is running, and this agent can call it.\" Use when: \"setup gbrain\",   \"connect gbrain\", \"start gbrain\", \"install gbrain\", \"configure gbrain for this machine\".   (gstack)",
+      "summary": "Set up gbrain for this coding agent: install the CLI, initialize a local   PGLite or Supabase brain, register MCP, capture per-remote trust policy. One command   from zero to \"gbrain is running, and this agent can call it.\" Use when: \"setup",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1309,7 +2157,15 @@
         "browser",
         "gstack",
         "setup-gbrain"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/context-memory/sync-gbrain",
@@ -1317,7 +2173,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/context-memory/sync-gbrain/SKILL.md",
       "description": "Keep gbrain current with this repo''s code and refresh agent search   guidance in CLAUDE.md. Wraps the gstack-gbrain-sync orchestrator with state probing,   native code-surface registration, capability checks, and a verdict block. Re-runnable,   idempotent. Use when: \"sync gbrain\", \"refresh gbrain\", \"re-index this repo\", \"gbrain   search isn''t finding things\". (gstack)",
+      "summary": "Keep gbrain current with this repo''s code and refresh agent search   guidance in CLAUDE.md. Wraps the gstack-gbrain-sync orchestrator with state probing,   native code-surface registration, capability checks, and a verdict block. Re-runnab",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1331,7 +2189,15 @@
         "browser",
         "gstack",
         "sync-gbrain"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/deploy-ship/document-release",
@@ -1339,7 +2205,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/deploy-ship/document-release/SKILL.md",
       "description": "Post-ship documentation update. Reads all project docs, cross-references   the diff, updates README/ARCHITECTURE/CONTRIBUTING/CLAUDE.md to match what shipped,   polishes CHANGELOG voice, cleans up TODOS, and optionally bumps VERSION. Use when   asked to \"update the docs\", \"sync documentation\", or \"post-ship docs\". Proactively   suggest after a PR is merged or code is shipped. (gstack)",
+      "summary": "Post-ship documentation update. Reads all project docs, cross-references   the diff, updates README/ARCHITECTURE/CONTRIBUTING/CLAUDE.md to match what shipped,   polishes CHANGELOG voice, cleans up TODOS, and optionally bumps VERSION. Use wh",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1353,7 +2221,15 @@
         "browser",
         "gstack",
         "document-release"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/deploy-ship/land-and-deploy",
@@ -1361,7 +2237,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/deploy-ship/land-and-deploy/SKILL.md",
       "description": "Land and deploy workflow. Merges the PR, waits for CI and deploy, verifies   production health via canary checks. Takes over after /ship creates the PR. Use   when: \"merge\", \"land\", \"deploy\", \"merge and verify\", \"land it\", \"ship it to production\".   (gstack)",
+      "summary": "Land and deploy workflow. Merges the PR, waits for CI and deploy, verifies   production health via canary checks. Takes over after /ship creates the PR. Use   when: \"merge\", \"land\", \"deploy\", \"merge and verify\", \"land it\", \"ship it to produ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1375,7 +2253,15 @@
         "browser",
         "gstack",
         "land-and-deploy"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/deploy-ship/landing-report",
@@ -1383,7 +2269,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/deploy-ship/landing-report/SKILL.md",
       "description": "Read-only queue dashboard for workspace-aware ship. Shows which VERSION   slots are currently claimed by open PRs, which sibling Conductor workspaces have   WIP work likely to ship soon, and what slot /ship would pick next. No mutations   — just a snapshot. Use when asked to \"landing report\", \"what's in the queue\", \"show   me open PRs\", or \"which version do I claim next\". (gstack)",
+      "summary": "Read-only queue dashboard for workspace-aware ship. Shows which VERSION   slots are currently claimed by open PRs, which sibling Conductor workspaces have   WIP work likely to ship soon, and what slot /ship would pick next. No mutations   —",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1397,7 +2285,15 @@
         "browser",
         "gstack",
         "landing-report"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/deploy-ship/setup-deploy",
@@ -1405,7 +2301,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/deploy-ship/setup-deploy/SKILL.md",
       "description": "Configure deployment settings for /land-and-deploy. Detects your deploy   platform (Fly.io, Render, Vercel, Netlify, Heroku, GitHub Actions, custom), production   URL, health check endpoints, and deploy status commands. Writes the configuration   to CLAUDE.md so all future deploys are automatic. Use when: \"setup deploy\", \"configure   deployment\", \"set up land-and-deploy\", \"how do I deploy with gstack\", \"add deploy   config\".",
+      "summary": "Configure deployment settings for /land-and-deploy. Detects your deploy   platform (Fly.io, Render, Vercel, Netlify, Heroku, GitHub Actions, custom), production   URL, health check endpoints, and deploy status commands. Writes the configura",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1419,7 +2317,15 @@
         "browser",
         "gstack",
         "setup-deploy"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/deploy-ship/ship",
@@ -1427,7 +2333,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/deploy-ship/ship/SKILL.md",
       "description": "Ship workflow: detect + merge base branch, run tests, review diff, bump   VERSION, update CHANGELOG, commit, push, create PR. Use when asked to \"ship\", \"deploy\",   \"push to main\", \"create a PR\", \"merge and push\", or \"get it deployed\". Proactively   invoke this skill (do NOT push/PR directly) when the user says code is ready, asks   about deploying, wants to push code up, or asks to create a PR. (gstack)",
+      "summary": "Ship workflow: detect + merge base branch, run tests, review diff, bump   VERSION, update CHANGELOG, commit, push, create PR. Use when asked to \"ship\", \"deploy\",   \"push to main\", \"create a PR\", \"merge and push\", or \"get it deployed\". Proac",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1440,7 +2348,15 @@
         "ship",
         "browser",
         "gstack"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/design/design-consultation",
@@ -1448,7 +2364,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/design/design-consultation/SKILL.md",
       "description": "Design consultation: understands your product, researches the landscape,   proposes a complete design system (aesthetic, typography, color, layout, spacing,   motion), and generates font+color preview pages. Creates DESIGN.md as your project''s   design source of truth. For existing sites, use /plan-design-review to infer the   system instead. Use when asked to \"design system\", \"brand guidelines\", or \"create   DESIGN.md\". Proactively suggest when starting a new project''s UI with no existing   d",
+      "summary": "Design consultation: understands your product, researches the landscape,   proposes a complete design system (aesthetic, typography, color, layout, spacing,   motion), and generates font+color preview pages. Creates DESIGN.md as your projec",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1462,7 +2380,15 @@
         "browser",
         "gstack",
         "design-consultation"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/design/design-html",
@@ -1470,7 +2396,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/design/design-html/SKILL.md",
       "description": "Design finalization: generates production-quality Pretext-native HTML/CSS.   Works with approved mockups from /design-shotgun, CEO plans from /plan-ceo-review,   design review context from /plan-design-review, or from scratch with a user description.   Text actually reflows, heights are computed, layouts are dynamic. 30KB overhead,   zero deps. Smart API routing: picks the right Pretext patterns for each design type.   Use when: \"finalize this design\", \"turn this into HTML\", \"build me a page\", \"",
+      "summary": "Design finalization: generates production-quality Pretext-native HTML/CSS.   Works with approved mockups from /design-shotgun, CEO plans from /plan-ceo-review,   design review context from /plan-design-review, or from scratch with a user de",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1484,7 +2412,15 @@
         "browser",
         "gstack",
         "design-html"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/design/design-review",
@@ -1492,7 +2428,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/design/design-review/SKILL.md",
       "description": "Designer''s eye QA: finds visual inconsistency, spacing issues, hierarchy   problems, AI slop patterns, and slow interactions — then fixes them. Iteratively   fixes issues in source code, committing each fix atomically and re-verifying with   before/after screenshots. For plan-mode design review (before implementation), use   /plan-design-review. Use when asked to \"audit the design\", \"visual QA\", \"check if   it looks good\", or \"design polish\". Proactively suggest when the user mentions visual   ",
+      "summary": "Designer''s eye QA: finds visual inconsistency, spacing issues, hierarchy   problems, AI slop patterns, and slow interactions — then fixes them. Iteratively   fixes issues in source code, committing each fix atomically and re-verifying with",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1506,7 +2444,15 @@
         "browser",
         "gstack",
         "design-review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/design/design-shotgun",
@@ -1514,7 +2460,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/design/design-shotgun/SKILL.md",
       "description": "Design shotgun: generate multiple AI design variants, open a comparison   board, collect structured feedback, and iterate. Standalone design exploration you   can run anytime. Use when: \"explore designs\", \"show me options\", \"design variants\",   \"visual brainstorm\", or \"I don''t like how this looks\". Proactively suggest when   the user describes a UI feature but hasn''t seen what it could look like. (gstack)",
+      "summary": "Design shotgun: generate multiple AI design variants, open a comparison   board, collect structured feedback, and iterate. Standalone design exploration you   can run anytime. Use when: \"explore designs\", \"show me options\", \"design variants",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1528,7 +2476,15 @@
         "browser",
         "gstack",
         "design-shotgun"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/plan-review/autoplan",
@@ -1536,7 +2492,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/plan-review/autoplan/SKILL.md",
       "description": "Auto-review pipeline — reads the full CEO, design, eng, and DX review   skills from disk and runs them sequentially with auto-decisions using 6 decision   principles. Surfaces taste decisions (close approaches, borderline scope, codex   disagreements) at a final approval gate. One command, fully reviewed plan out. Use   when asked to \"auto review\", \"autoplan\", \"run all reviews\", \"review this plan automatically\",   or \"make the decisions for me\". Proactively suggest when the user has a plan file ",
+      "summary": "Auto-review pipeline — reads the full CEO, design, eng, and DX review   skills from disk and runs them sequentially with auto-decisions using 6 decision   principles. Surfaces taste decisions (close approaches, borderline scope, codex   dis",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1550,7 +2508,15 @@
         "browser",
         "gstack",
         "autoplan"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/plan-review/devex-review",
@@ -1558,7 +2524,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/plan-review/devex-review/SKILL.md",
       "description": "Live developer experience audit. Uses the browse tool to actually TEST   the developer experience: navigates docs, tries the getting started flow, times   TTHW, screenshots error messages, evaluates CLI help text. Produces a DX scorecard   with evidence. Compares against /plan-devex-review scores if they exist (the boomerang:   plan said 3 minutes, reality says 8). Use when asked to \"test the DX\", \"DX audit\",   \"developer experience test\", or \"try the onboarding\". Proactively suggest after   shi",
+      "summary": "Live developer experience audit. Uses the browse tool to actually TEST   the developer experience: navigates docs, tries the getting started flow, times   TTHW, screenshots error messages, evaluates CLI help text. Produces a DX scorecard   ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1572,7 +2540,15 @@
         "browser",
         "gstack",
         "devex-review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/plan-review/plan-ceo-review",
@@ -1580,7 +2556,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/plan-review/plan-ceo-review/SKILL.md",
       "description": "CEO/founder-mode plan review. Rethink the problem, find the 10-star   product, challenge premises, expand scope when it creates a better product. Four   modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick   expansions), HOLD SCOPE (maximum rigor), SCOPE REDUCTION (strip to essentials).   Use when asked to \"think bigger\", \"expand scope\", \"strategy review\", \"rethink this\",   or \"is this ambitious enough\". Proactively suggest when the user is questioning   scope or amb",
+      "summary": "CEO/founder-mode plan review. Rethink the problem, find the 10-star   product, challenge premises, expand scope when it creates a better product. Four   modes: SCOPE EXPANSION (dream big), SELECTIVE EXPANSION (hold scope + cherry-pick   exp",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1594,7 +2572,15 @@
         "browser",
         "gstack",
         "plan-ceo-review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/plan-review/plan-design-review",
@@ -1602,7 +2588,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/plan-review/plan-design-review/SKILL.md",
       "description": "Designer's eye plan review — interactive, like CEO and Eng review. Rates   each design dimension 0-10, explains what would make it a 10, then fixes the plan   to get there. Works in plan mode. For live site visual audits, use /design-review.   Use when asked to \"review the design plan\" or \"design critique\". Proactively suggest   when the user has a plan with UI/UX components that should be reviewed before implementation.   (gstack)",
+      "summary": "Designer's eye plan review — interactive, like CEO and Eng review. Rates   each design dimension 0-10, explains what would make it a 10, then fixes the plan   to get there. Works in plan mode. For live site visual audits, use /design-review",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1616,7 +2604,15 @@
         "browser",
         "gstack",
         "plan-design-review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/plan-review/plan-devex-review",
@@ -1624,7 +2620,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/plan-review/plan-devex-review/SKILL.md",
       "description": "Interactive developer experience plan review. Explores developer personas,   benchmarks against competitors, designs magical moments, and traces friction points   before scoring. Three modes: DX EXPANSION (competitive advantage), DX POLISH (bulletproof   every touchpoint), DX TRIAGE (critical gaps only). Use when asked to \"DX review\",   \"developer experience audit\", \"devex review\", or \"API design review\". Proactively   suggest when the user has a plan for developer-facing products (APIs, CLIs, S",
+      "summary": "Interactive developer experience plan review. Explores developer personas,   benchmarks against competitors, designs magical moments, and traces friction points   before scoring. Three modes: DX EXPANSION (competitive advantage), DX POLISH ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1638,7 +2636,15 @@
         "browser",
         "gstack",
         "plan-devex-review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/plan-review/plan-eng-review",
@@ -1646,7 +2652,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/plan-review/plan-eng-review/SKILL.md",
       "description": "Eng manager-mode plan review. Lock in the execution plan — architecture,   data flow, diagrams, edge cases, test coverage, performance. Walks through issues   interactively with opinionated recommendations. Use when asked to \"review the architecture\",   \"engineering review\", or \"lock in the plan\". Proactively suggest when the user has   a plan or design doc and is about to start coding — to catch architecture issues   before implementation. (gstack) Voice triggers (speech-to-text aliases): \"tech",
+      "summary": "Eng manager-mode plan review. Lock in the execution plan — architecture,   data flow, diagrams, edge cases, test coverage, performance. Walks through issues   interactively with opinionated recommendations. Use when asked to \"review the arc",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1660,7 +2668,15 @@
         "browser",
         "gstack",
         "plan-eng-review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/plan-review/plan-tune",
@@ -1668,7 +2684,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/plan-review/plan-tune/SKILL.md",
       "description": "Self-tuning question sensitivity + developer psychographic for gstack   (v1: observational). Review which AskUserQuestion prompts fire across gstack skills,   set per-question preferences (never-ask / always-ask / ask-only-for-one-way), inspect   the dual-track profile (what you declared vs what your behavior suggests), and enable/disable   question tuning. Conversational interface — no CLI syntax required. Use when asked   to \"tune questions\", \"stop asking me that\", \"too many questions\", \"show ",
+      "summary": "Self-tuning question sensitivity + developer psychographic for gstack   (v1: observational). Review which AskUserQuestion prompts fire across gstack skills,   set per-question preferences (never-ask / always-ask / ask-only-for-one-way), ins",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1682,7 +2700,15 @@
         "browser",
         "gstack",
         "plan-tune"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/remote-agents/openclaw/gstack-openclaw-ceo-review",
@@ -1690,7 +2716,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/remote-agents/openclaw/gstack-openclaw-ceo-review/SKILL.md",
       "description": "Use when asked to review a plan, challenge a proposal, run a CEO review,   poke holes in an approach, think bigger about scope, or decide whether to expand   or reduce the plan.",
+      "summary": "Use when asked to review a plan, challenge a proposal, run a CEO review,   poke holes in an approach, think bigger about scope, or decide whether to expand   or reduce the plan.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1704,7 +2732,15 @@
         "browser",
         "gstack",
         "gstack-openclaw-ceo-review"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/remote-agents/openclaw/gstack-openclaw-investigate",
@@ -1712,7 +2748,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/remote-agents/openclaw/gstack-openclaw-investigate/SKILL.md",
       "description": "Use when asked to debug, fix a bug, investigate an error, or do root   cause analysis, and when users report errors, stack traces, unexpected behavior,   or say something stopped working.",
+      "summary": "Use when asked to debug, fix a bug, investigate an error, or do root   cause analysis, and when users report errors, stack traces, unexpected behavior,   or say something stopped working.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1726,7 +2764,15 @@
         "browser",
         "gstack",
         "gstack-openclaw-investigate"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/remote-agents/openclaw/gstack-openclaw-office-hours",
@@ -1734,7 +2780,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/remote-agents/openclaw/gstack-openclaw-office-hours/SKILL.md",
       "description": "Use when asked to brainstorm, evaluate whether an idea is worth building,   run office hours, or think through a new product idea or design direction before   any code is written.",
+      "summary": "Use when asked to brainstorm, evaluate whether an idea is worth building,   run office hours, or think through a new product idea or design direction before   any code is written.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1748,7 +2796,15 @@
         "browser",
         "gstack",
         "gstack-openclaw-office-hours"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/remote-agents/openclaw/gstack-openclaw-retro",
@@ -1756,7 +2812,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/remote-agents/openclaw/gstack-openclaw-retro/SKILL.md",
       "description": "Weekly engineering retrospective. Analyzes commit history, work patterns,   and code quality metrics with persistent history and trend tracking. Team-aware   with per-person contributions, praise, and growth areas. Use when asked for weekly   retro, what shipped this week, or engineering retrospective.",
+      "summary": "Weekly engineering retrospective. Analyzes commit history, work patterns,   and code quality metrics with persistent history and trend tracking. Team-aware   with per-person contributions, praise, and growth areas. Use when asked for weekly",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1770,7 +2828,15 @@
         "browser",
         "gstack",
         "gstack-openclaw-retro"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/remote-agents/pair-agent",
@@ -1778,7 +2844,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/remote-agents/pair-agent/SKILL.md",
       "description": "Pair a remote AI agent with your browser. One command generates a setup   key and prints instructions the other agent can follow to connect. Works with OpenClaw,   Hermes, Codex, Cursor, or any agent that can make HTTP requests. The remote agent   gets its own tab with scoped access (read+write by default, admin on request). Use   when asked to \"pair agent\", \"connect agent\", \"share browser\", \"remote browser\",   \"let another agent use my browser\", or \"give browser access\". (gstack) Voice triggers",
+      "summary": "Pair a remote AI agent with your browser. One command generates a setup   key and prints instructions the other agent can follow to connect. Works with OpenClaw,   Hermes, Codex, Cursor, or any agent that can make HTTP requests. The remote ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1792,7 +2860,15 @@
         "browser",
         "gstack",
         "pair-agent"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/scrape/browser-skills/hackernews-frontpage",
@@ -1800,7 +2876,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/scrape/browser-skills/hackernews-frontpage/SKILL.md",
       "description": "Scrape the Hacker News front page (titles, points, comment counts).",
+      "summary": "Scrape the Hacker News front page (titles, points, comment counts).",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1814,7 +2892,15 @@
         "browser",
         "gstack",
         "hackernews-frontpage"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/scrape/scrape",
@@ -1822,7 +2908,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/scrape/scrape/SKILL.md",
       "description": "Pull data from a web page. First call on a new intent prototypes the   flow via $B primitives and returns JSON. Subsequent calls on a matching intent route   to a codified browser-skill and return in ~200ms. Read-only — for mutating flows   (form fills, clicks, submissions), use /automate. Use when asked to \"scrape\", \"get   data from\", \"pull\", \"extract from\", or \"what's on\" a page. (gstack)",
+      "summary": "Pull data from a web page. First call on a new intent prototypes the   flow via $B primitives and returns JSON. Subsequent calls on a matching intent route   to a codified browser-skill and return in ~200ms. Read-only — for mutating flows  ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1836,7 +2924,15 @@
         "browser",
         "gstack",
         "scrape"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/scrape/skillify",
@@ -1844,7 +2940,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/scrape/skillify/SKILL.md",
       "description": "Codify the most recent successful /scrape flow into a permanent browser-skill   on disk. Future /scrape calls with the same intent run the codified script in ~200ms   instead of re-driving the page. Walks back through the conversation, synthesizes   script.ts + script.test.ts + fixture, runs the test in a temp dir, and asks before   committing. Use when asked to \"skillify\", \"codify\", \"save this scrape\", or \"make   this permanent\". (gstack)",
+      "summary": "Codify the most recent successful /scrape flow into a permanent browser-skill   on disk. Future /scrape calls with the same intent run the codified script in ~200ms   instead of re-driving the page. Walks back through the conversation, synt",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1858,7 +2956,15 @@
         "browser",
         "gstack",
         "skillify"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/security-safety/careful",
@@ -1866,7 +2972,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/security-safety/careful/SKILL.md",
       "description": "Safety guardrails for destructive commands. Warns before rm -rf, DROP   TABLE, force-push, git reset --hard, kubectl delete, and similar destructive operations.   User can override each warning. Use when touching prod, debugging live systems,   or working in a shared environment. Use when asked to \"be careful\", \"safety mode\",   \"prod mode\", or \"careful mode\". (gstack)",
+      "summary": "Safety guardrails for destructive commands. Warns before rm -rf, DROP   TABLE, force-push, git reset --hard, kubectl delete, and similar destructive operations.   User can override each warning. Use when touching prod, debugging live system",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1880,7 +2988,15 @@
         "browser",
         "gstack",
         "careful"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/security-safety/cso",
@@ -1888,7 +3004,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/security-safety/cso/SKILL.md",
       "description": "Chief Security Officer mode. Infrastructure-first security audit: secrets   archaeology, dependency supply chain, CI/CD pipeline security, LLM/AI security,   skill supply chain scanning, plus OWASP Top 10, STRIDE threat modeling, and active   verification. Two modes: daily (zero-noise, 8/10 confidence gate) and comprehensive   (monthly deep scan, 2/10 bar). Trend tracking across audit runs. Use when: \"security   audit\", \"threat model\", \"pentest review\", \"OWASP\", \"CSO review\". (gstack) Voice   tr",
+      "summary": "Chief Security Officer mode. Infrastructure-first security audit: secrets   archaeology, dependency supply chain, CI/CD pipeline security, LLM/AI security,   skill supply chain scanning, plus OWASP Top 10, STRIDE threat modeling, and active",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1902,7 +3020,15 @@
         "browser",
         "gstack",
         "cso"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/security-safety/freeze",
@@ -1910,7 +3036,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/security-safety/freeze/SKILL.md",
       "description": "Restrict file edits to a specific directory for the session. Blocks Edit   and Write outside the allowed path. Use when debugging to prevent accidentally \"fixing\"   unrelated code, or when you want to scope changes to one module. Use when asked   to \"freeze\", \"restrict edits\", \"only edit this folder\", or \"lock down edits\". (gstack)",
+      "summary": "Restrict file edits to a specific directory for the session. Blocks Edit   and Write outside the allowed path. Use when debugging to prevent accidentally \"fixing\"   unrelated code, or when you want to scope changes to one module. Use when a",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1924,7 +3052,15 @@
         "browser",
         "gstack",
         "freeze"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/security-safety/guard",
@@ -1932,7 +3068,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/security-safety/guard/SKILL.md",
       "description": "Full safety mode: destructive command warnings + directory-scoped edits.   Combines /careful (warns before rm -rf, DROP TABLE, force-push, etc.) with /freeze   (blocks edits outside a specified directory). Use for maximum safety when touching   prod or debugging live systems. Use when asked to \"guard mode\", \"full safety\", \"lock   it down\", or \"maximum safety\". (gstack)",
+      "summary": "Full safety mode: destructive command warnings + directory-scoped edits.   Combines /careful (warns before rm -rf, DROP TABLE, force-push, etc.) with /freeze   (blocks edits outside a specified directory). Use for maximum safety when touchi",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1946,7 +3084,15 @@
         "browser",
         "gstack",
         "guard"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/security-safety/unfreeze",
@@ -1954,7 +3100,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/security-safety/unfreeze/SKILL.md",
       "description": "Clear the freeze boundary set by /freeze, allowing edits to all directories   again. Use when you want to widen edit scope without ending the session. Use when   asked to \"unfreeze\", \"unlock edits\", \"remove freeze\", or \"allow all edits\". (gstack)",
+      "summary": "Clear the freeze boundary set by /freeze, allowing edits to all directories   again. Use when you want to widen edit scope without ending the session. Use when   asked to \"unfreeze\", \"unlock edits\", \"remove freeze\", or \"allow all edits\". (g",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1968,7 +3116,15 @@
         "browser",
         "gstack",
         "unfreeze"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/utility/gstack-upgrade",
@@ -1976,7 +3132,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/utility/gstack-upgrade/SKILL.md",
       "description": "Upgrade gstack to the latest version. Detects global vs vendored install,   runs the upgrade, and shows what''s new. Use when asked to \"upgrade gstack\", \"update   gstack\", or \"get latest version\". Voice triggers (speech-to-text aliases): \"upgrade   the tools\", \"update the tools\", \"gee stack upgrade\", \"g stack upgrade\".",
+      "summary": "Upgrade gstack to the latest version. Detects global vs vendored install,   runs the upgrade, and shows what''s new. Use when asked to \"upgrade gstack\", \"update   gstack\", or \"get latest version\". Voice triggers (speech-to-text aliases): \"u",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -1990,7 +3148,15 @@
         "browser",
         "gstack",
         "gstack-upgrade"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/utility/office-hours",
@@ -1998,7 +3164,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/utility/office-hours/SKILL.md",
       "description": "YC Office Hours — two modes. Startup mode: six forcing questions that   expose demand reality, status quo, desperate specificity, narrowest wedge, observation,   and future-fit. Builder mode: design thinking brainstorming for side projects, hackathons,   learning, and open source. Saves a design doc. Use when asked to \"brainstorm this\",   \"I have an idea\", \"help me think through this\", \"office hours\", or \"is this worth   building\". Proactively invoke this skill (do NOT answer directly) when the ",
+      "summary": "YC Office Hours — two modes. Startup mode: six forcing questions that   expose demand reality, status quo, desperate specificity, narrowest wedge, observation,   and future-fit. Builder mode: design thinking brainstorming for side projects,",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -2012,7 +3180,15 @@
         "browser",
         "gstack",
         "office-hours"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/utility/open-gstack-browser",
@@ -2020,7 +3196,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/utility/open-gstack-browser/SKILL.md",
       "description": "Launch GStack Browser — AI-controlled Chromium with the sidebar extension   baked in. Opens a visible browser window where you can watch every action in real   time. The sidebar shows a live activity feed and chat. Anti-bot stealth built in.   Use when asked to \"open gstack browser\", \"launch browser\", \"connect chrome\", \"open   chrome\", \"real browser\", \"launch chrome\", \"side panel\", or \"control my browser\".   Voice triggers (speech-to-text aliases): \"show me the browser\".",
+      "summary": "Launch GStack Browser — AI-controlled Chromium with the sidebar extension   baked in. Opens a visible browser window where you can watch every action in real   time. The sidebar shows a live activity feed and chat. Anti-bot stealth built in",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -2034,7 +3212,15 @@
         "browser",
         "gstack",
         "open-gstack-browser"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/utility/retro",
@@ -2042,7 +3228,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/utility/retro/SKILL.md",
       "description": "Weekly engineering retrospective. Analyzes commit history, work patterns,   and code quality metrics with persistent history and trend tracking. Team-aware:   breaks down per-person contributions with praise and growth areas. Use when asked   to \"weekly retro\", \"what did we ship\", or \"engineering retrospective\". Proactively   suggest at the end of a work week or sprint. (gstack)",
+      "summary": "Weekly engineering retrospective. Analyzes commit history, work patterns,   and code quality metrics with persistent history and trend tracking. Team-aware:   breaks down per-person contributions with praise and growth areas. Use when asked",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -2056,7 +3244,15 @@
         "browser",
         "gstack",
         "retro"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "gstack/utility/setup-browser-cookies",
@@ -2064,7 +3260,9 @@
       "domain": "gstack",
       "path": ".cursor/skills/gstack/utility/setup-browser-cookies/SKILL.md",
       "description": "Import cookies from your real Chromium browser into the headless browse   session. Opens an interactive picker UI where you select which cookie domains to   import. Use before QA testing authenticated pages. Use when asked to \"import cookies\",   \"login to the site\", or \"authenticate the browser\". (gstack)",
+      "summary": "Import cookies from your real Chromium browser into the headless browse   session. Opens an interactive picker UI where you select which cookie domains to   import. Use before QA testing authenticated pages. Use when asked to \"import cookie",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "medium",
       "formats": [
         "cursor",
@@ -2078,7 +3276,15 @@
         "browser",
         "gstack",
         "setup-browser-cookies"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "marketing/meta-ads-analyzer",
@@ -2086,7 +3292,16 @@
       "domain": "marketing",
       "path": ".cursor/skills/marketing/meta-ads-analyzer/SKILL.md",
       "description": "Analyze Meta (Facebook/Instagram) ad performance—campaign structure, breakdowns, marginal vs average CPA, and scaling decisions. Analytical workflow only, not financial or legal advice. Triggers: \"Meta ads\", \"Facebook ads\", \"CPA\", \"ROAS\", \"ad account\", \"Breakdown Effect\".",
+      "summary": "Analyze Meta (Facebook/Instagram) ad performance—campaign structure, breakdowns, marginal vs average CPA, and scaling decisions. Analytical workflow only, not financial or legal advice. Triggers: \"Meta ads\", \"Facebook ads\", \"CPA\", \"ROAS\", \"",
       "triggers": [
+        "Meta ads",
+        "Facebook ads",
+        "CPA",
+        "ROAS",
+        "ad account",
+        "Breakdown Effect"
+      ],
+      "trigger_phrases": [
         "Meta ads",
         "Facebook ads",
         "CPA",
@@ -2105,7 +3320,15 @@
         "marketing",
         "ads",
         "meta-ads-analyzer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "meta-tools/autoskill",
@@ -2113,7 +3336,9 @@
       "domain": "meta-tools",
       "path": ".cursor/skills/meta-tools/autoskill/SKILL.md",
       "description": "Observe the user's screen via screenpipe, detect repeated research workflows, match them against existing scientific-agent-skills, and draft new skills (or composition recipes that chain existing ones) for the patterns not yet covered. Use when the user asks to analyze their recent work and propose skills based on what they actually do. Requires the screenpipe daemon (https://github.com/screenpipe/screenpipe) running locally on port 3030 — the skill has no other data source and will refuse to ru",
+      "summary": "Observe the user's screen via screenpipe, detect repeated research workflows, match them against existing scientific-agent-skills, and draft new skills (or composition recipes that chain existing ones) for the patterns not yet covered. Use ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2125,7 +3350,15 @@
         "meta",
         "skills",
         "autoskill"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "meta-tools/reflect-yourself",
@@ -2133,7 +3366,9 @@
       "domain": "meta-tools",
       "path": ".cursor/skills/meta-tools/reflect-yourself/SKILL.md",
       "description": "Self-learning system that captures corrections, discovers workflow patterns, and syncs learnings to skills and rules. Use when ending a session, after corrections, or when the user wants to formalize learnings (v1.1.3).",
+      "summary": "Self-learning system that captures corrections, discovers workflow patterns, and syncs learnings to skills and rules. Use when ending a session, after corrections, or when the user wants to formalize learnings (v1.1.3).",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2145,7 +3380,15 @@
         "meta",
         "skills",
         "reflect-yourself"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "meta-tools/reflect-yourself/skill-examples/phase-kickoff",
@@ -2153,7 +3396,9 @@
       "domain": "meta-tools",
       "path": ".cursor/skills/meta-tools/reflect-yourself/skill-examples/phase-kickoff/SKILL.md",
       "description": "Convert the current phase doc into an ordered execution plan and propose work packages (spec-first + tiered tests), including RTL/Hebrew checks.",
+      "summary": "Convert the current phase doc into an ordered execution plan and propose work packages (spec-first + tiered tests), including RTL/Hebrew checks.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2165,7 +3410,55 @@
         "meta",
         "skills",
         "phase-kickoff"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
+    },
+    {
+      "id": "meta-tools/writing-skills",
+      "name": "writing-skills",
+      "domain": "meta-tools",
+      "path": ".cursor/skills/meta-tools/writing-skills/SKILL.md",
+      "description": ">   Author and pressure-test agent skills—triggers, thin SKILL.md, references, validation.   Use when creating or revising skills in this repo. Triggers: \"write a skill\", \"new skill\",   \"skill authoring\", \"improve skill triggers\".",
+      "summary": ">   Author and pressure-test agent skills—triggers, thin SKILL.md, references, validation.   Use when creating or revising skills in this repo. Triggers: \"write a skill\", \"new skill\",   \"skill authoring\", \"improve skill triggers\".",
+      "triggers": [
+        "write a skill",
+        "new skill",
+        "skill authoring",
+        "improve skill triggers"
+      ],
+      "trigger_phrases": [
+        "write a skill",
+        "new skill",
+        "skill authoring",
+        "improve skill triggers"
+      ],
+      "risk": "low",
+      "formats": [
+        "cursor",
+        "claude"
+      ],
+      "source": "awesome-agent-skill",
+      "license": "MIT",
+      "tags": [
+        "meta",
+        "skills",
+        "writing-skills"
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "ml-dl/pytorch-lightning",
@@ -2173,7 +3466,9 @@
       "domain": "ml-dl",
       "path": ".cursor/skills/ml-dl/pytorch-lightning/SKILL.md",
       "description": "Deep learning framework (PyTorch Lightning). Organize PyTorch code into LightningModules, configure Trainers for multi-GPU/TPU, implement data pipelines, callbacks, logging (W&B, TensorBoard), distributed training (DDP, FSDP, DeepSpeed), for scalable neural network training.",
+      "summary": "Deep learning framework (PyTorch Lightning). Organize PyTorch code into LightningModules, configure Trainers for multi-GPU/TPU, implement data pipelines, callbacks, logging (W&B, TensorBoard), distributed training (DDP, FSDP, DeepSpeed), fo",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2185,7 +3480,15 @@
         "ml",
         "deep-learning",
         "pytorch-lightning"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "ml-dl/scikit-learn",
@@ -2193,7 +3496,9 @@
       "domain": "ml-dl",
       "path": ".cursor/skills/ml-dl/scikit-learn/SKILL.md",
       "description": "Machine learning in Python with scikit-learn. Use when working with supervised learning (classification, regression), unsupervised learning (clustering, dimensionality reduction), model evaluation, hyperparameter tuning, preprocessing, or building ML pipelines. Provides comprehensive reference documentation for algorithms, preprocessing techniques, pipelines, and best practices.",
+      "summary": "Machine learning in Python with scikit-learn. Use when working with supervised learning (classification, regression), unsupervised learning (clustering, dimensionality reduction), model evaluation, hyperparameter tuning, preprocessing, or b",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2205,7 +3510,15 @@
         "ml",
         "deep-learning",
         "scikit-learn"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "ml-dl/scikit-survival",
@@ -2213,7 +3526,9 @@
       "domain": "ml-dl",
       "path": ".cursor/skills/ml-dl/scikit-survival/SKILL.md",
       "description": "Comprehensive toolkit for survival analysis and time-to-event modeling in Python using scikit-survival. Use this skill when working with censored survival data, performing time-to-event analysis, fitting Cox models, Random Survival Forests, Gradient Boosting models, or Survival SVMs, evaluating survival predictions with concordance index or Brier score, handling competing risks, or implementing any survival analysis workflow with the scikit-survival library.",
+      "summary": "Comprehensive toolkit for survival analysis and time-to-event modeling in Python using scikit-survival. Use this skill when working with censored survival data, performing time-to-event analysis, fitting Cox models, Random Survival Forests,",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2225,7 +3540,15 @@
         "ml",
         "deep-learning",
         "scikit-survival"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "ml-dl/transformers",
@@ -2233,7 +3556,9 @@
       "domain": "ml-dl",
       "path": ".cursor/skills/ml-dl/transformers/SKILL.md",
       "description": "This skill should be used when working with pre-trained transformer models for natural language processing, computer vision, audio, or multimodal tasks. Use for text generation, classification, question answering, translation, summarization, image classification, object detection, speech recognition, and fine-tuning models on custom datasets.",
+      "summary": "This skill should be used when working with pre-trained transformer models for natural language processing, computer vision, audio, or multimodal tasks. Use for text generation, classification, question answering, translation, summarization",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2245,7 +3570,15 @@
         "ml",
         "deep-learning",
         "transformers"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "mobile/app-store-submission-packager",
@@ -2253,7 +3586,15 @@
       "domain": "mobile",
       "path": ".cursor/skills/mobile/app-store-submission-packager/SKILL.md",
       "description": "Prepare iOS App Store and Google Play submissions—metadata, assets, compliance checks, and release checklist. Use before store upload or review submission. Triggers: \"App Store\", \"Play Store\", \"store submission\", \"app review\", \"release checklist\".",
+      "summary": "Prepare iOS App Store and Google Play submissions—metadata, assets, compliance checks, and release checklist. Use before store upload or review submission. Triggers: \"App Store\", \"Play Store\", \"store submission\", \"app review\", \"release chec",
       "triggers": [
+        "App Store",
+        "Play Store",
+        "store submission",
+        "app review",
+        "release checklist"
+      ],
+      "trigger_phrases": [
         "App Store",
         "Play Store",
         "store submission",
@@ -2272,7 +3613,15 @@
         "ios",
         "android",
         "app-store-submission-packager"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "mobile/ios-testflight-github-actions",
@@ -2280,7 +3629,15 @@
       "domain": "mobile",
       "path": ".cursor/skills/mobile/ios-testflight-github-actions/SKILL.md",
       "description": "Set up iOS TestFlight delivery via GitHub Actions—build, sign, upload—with secret hygiene and no auto-push. Triggers: \"TestFlight\", \"iOS CI\", \"Fastlane GitHub Actions\", \"beta release\", \"App Store Connect upload\".",
+      "summary": "Set up iOS TestFlight delivery via GitHub Actions—build, sign, upload—with secret hygiene and no auto-push. Triggers: \"TestFlight\", \"iOS CI\", \"Fastlane GitHub Actions\", \"beta release\", \"App Store Connect upload\".",
       "triggers": [
+        "TestFlight",
+        "iOS CI",
+        "Fastlane GitHub Actions",
+        "beta release",
+        "App Store Connect upload"
+      ],
+      "trigger_phrases": [
         "TestFlight",
         "iOS CI",
         "Fastlane GitHub Actions",
@@ -2299,7 +3656,15 @@
         "ios",
         "android",
         "ios-testflight-github-actions"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "performance/performance-optimization",
@@ -2307,7 +3672,16 @@
       "domain": "performance",
       "path": ".cursor/skills/performance/performance-optimization/SKILL.md",
       "description": ">   Measure, identify bottlenecks, fix, verify, and guard performance regressions.   Use for web vitals, slow APIs, heavy notebooks/pipelines, or video/render workloads.   Triggers: \"performance\", \"optimize\", \"slow\", \"latency\", \"bundle size\", \"profiling\".",
+      "summary": ">   Measure, identify bottlenecks, fix, verify, and guard performance regressions.   Use for web vitals, slow APIs, heavy notebooks/pipelines, or video/render workloads.   Triggers: \"performance\", \"optimize\", \"slow\", \"latency\", \"bundle size",
       "triggers": [
+        "performance",
+        "optimize",
+        "slow",
+        "latency",
+        "bundle size",
+        "profiling"
+      ],
+      "trigger_phrases": [
         "performance",
         "optimize",
         "slow",
@@ -2325,7 +3699,15 @@
       "tags": [
         "performance",
         "performance-optimization"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "product-growth/product-analytics-experiments",
@@ -2333,7 +3715,15 @@
       "domain": "product-growth",
       "path": ".cursor/skills/product-growth/product-analytics-experiments/SKILL.md",
       "description": ">   Product analytics and experimentation—event design, funnel metrics, tracking   plans, and A/B test setup with statistical and operational gates. Use when   defining metrics, launch experiments, or reviewing growth/DS product work.   Triggers: \"A/B test\", \"experiment\", \"funnel\", \"tracking plan\", \"product analytics\".",
+      "summary": ">   Product analytics and experimentation—event design, funnel metrics, tracking   plans, and A/B test setup with statistical and operational gates. Use when   defining metrics, launch experiments, or reviewing growth/DS product work.   Tri",
       "triggers": [
+        "A/B test",
+        "experiment",
+        "funnel",
+        "tracking plan",
+        "product analytics"
+      ],
+      "trigger_phrases": [
         "A/B test",
         "experiment",
         "funnel",
@@ -2351,7 +3741,15 @@
         "product",
         "growth",
         "product-analytics-experiments"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "product-growth/product-offer-design",
@@ -2359,7 +3757,15 @@
       "domain": "product-growth",
       "path": ".cursor/skills/product-growth/product-offer-design/SKILL.md",
       "description": "Package workflows and capabilities into clear product offers—audience, outcome, scope, and delivery format. Neutral framing without fixed pricing dogma. Triggers: \"product offer\", \"package this\", \"what to sell\", \"positioning\", \"service productization\".",
+      "summary": "Package workflows and capabilities into clear product offers—audience, outcome, scope, and delivery format. Neutral framing without fixed pricing dogma. Triggers: \"product offer\", \"package this\", \"what to sell\", \"positioning\", \"service prod",
       "triggers": [
+        "product offer",
+        "package this",
+        "what to sell",
+        "positioning",
+        "service productization"
+      ],
+      "trigger_phrases": [
         "product offer",
         "package this",
         "what to sell",
@@ -2377,7 +3783,15 @@
         "product",
         "growth",
         "product-offer-design"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "reflect-yourself",
@@ -2385,7 +3799,9 @@
       "domain": "reflect-yourself",
       "path": ".cursor/skills/reflect-yourself/SKILL.md",
       "description": "Self-learning system that captures corrections, discovers workflow patterns, and syncs learnings to skills and rules. Use when ending a session, after corrections, or when the user wants to formalize learnings (v1.1.3).",
+      "summary": "Self-learning system that captures corrections, discovers workflow patterns, and syncs learnings to skills and rules. Use when ending a session, after corrections, or when the user wants to formalize learnings (v1.1.3).",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2395,7 +3811,15 @@
       "license": "MIT",
       "tags": [
         "reflect-yourself"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "reflect-yourself/skill-examples/phase-kickoff",
@@ -2403,7 +3827,9 @@
       "domain": "reflect-yourself",
       "path": ".cursor/skills/reflect-yourself/skill-examples/phase-kickoff/SKILL.md",
       "description": "Convert the current phase doc into an ordered execution plan and propose work packages (spec-first + tiered tests), including RTL/Hebrew checks.",
+      "summary": "Convert the current phase doc into an ordered execution plan and propose work packages (spec-first + tiered tests), including RTL/Hebrew checks.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2414,7 +3840,15 @@
       "tags": [
         "reflect-yourself",
         "phase-kickoff"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "reliability-ops/ci-cd-quality-gates",
@@ -2422,7 +3856,15 @@
       "domain": "reliability-ops",
       "path": ".cursor/skills/reliability-ops/ci-cd-quality-gates/SKILL.md",
       "description": ">   Design lightweight CI quality gates—lint, test tiers, security scans, and merge   policies. Use when setting up or improving pipelines without tying to one stack only.   Triggers: \"CI\", \"quality gate\", \"pipeline\", \"GitHub Actions\", \"pre-merge checks\".",
+      "summary": ">   Design lightweight CI quality gates—lint, test tiers, security scans, and merge   policies. Use when setting up or improving pipelines without tying to one stack only.   Triggers: \"CI\", \"quality gate\", \"pipeline\", \"GitHub Actions\", \"pre",
       "triggers": [
+        "CI",
+        "quality gate",
+        "pipeline",
+        "GitHub Actions",
+        "pre-merge checks"
+      ],
+      "trigger_phrases": [
         "CI",
         "quality gate",
         "pipeline",
@@ -2442,7 +3884,15 @@
         "launch",
         "observability",
         "ci-cd-quality-gates"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "reliability-ops/cross-platform-error-handling",
@@ -2450,7 +3900,15 @@
       "domain": "reliability-ops",
       "path": ".cursor/skills/reliability-ops/cross-platform-error-handling/SKILL.md",
       "description": "Design consistent error handling across web, mobile, and React Native—central handlers, user-facing copy, retry, and logging. Triggers: \"error handling\", \"error boundary\", \"toast\", \"React Native errors\", \"global handler\".",
+      "summary": "Design consistent error handling across web, mobile, and React Native—central handlers, user-facing copy, retry, and logging. Triggers: \"error handling\", \"error boundary\", \"toast\", \"React Native errors\", \"global handler\".",
       "triggers": [
+        "error handling",
+        "error boundary",
+        "toast",
+        "React Native errors",
+        "global handler"
+      ],
+      "trigger_phrases": [
         "error handling",
         "error boundary",
         "toast",
@@ -2470,7 +3928,15 @@
         "launch",
         "observability",
         "cross-platform-error-handling"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "reliability-ops/dynamic-config-management",
@@ -2478,7 +3944,12 @@
       "domain": "reliability-ops",
       "path": ".cursor/skills/reliability-ops/dynamic-config-management/SKILL.md",
       "description": "Manage application configuration—schemas, validation, .env.example, placeholder detection, fail-fast startup. Use when adding env vars or centralizing config. Triggers: \"config\", \"environment variables\", \".env\", \"settings\", \"fail fast\", \"config schema\".",
+      "summary": "Manage application configuration—schemas, validation, .env.example, placeholder detection, fail-fast startup. Use when adding env vars or centralizing config. Triggers: \"config\", \"environment variables\", \".env\", \"settings\", \"fail fast\", \"co",
       "triggers": [
+        "config",
+        "environment variables"
+      ],
+      "trigger_phrases": [
         "config",
         "environment variables"
       ],
@@ -2495,7 +3966,15 @@
         "launch",
         "observability",
         "dynamic-config-management"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "reliability-ops/observability-slo",
@@ -2503,7 +3982,16 @@
       "domain": "reliability-ops",
       "path": ".cursor/skills/reliability-ops/observability-slo/SKILL.md",
       "description": ">   Lightweight observability and SLO practice—SLIs, SLO targets, error budgets,   logs, metrics, traces, and alerting for apps and data pipelines.   Use when defining monitoring, on-call alerts, or reliability targets.   Triggers: \"SLO\", \"SLI\", \"observability\", \"alerting\", \"error budget\", \"monitoring\".",
+      "summary": ">   Lightweight observability and SLO practice—SLIs, SLO targets, error budgets,   logs, metrics, traces, and alerting for apps and data pipelines.   Use when defining monitoring, on-call alerts, or reliability targets.   Triggers: \"SLO\", \"",
       "triggers": [
+        "SLO",
+        "SLI",
+        "observability",
+        "alerting",
+        "error budget",
+        "monitoring"
+      ],
+      "trigger_phrases": [
         "SLO",
         "SLI",
         "observability",
@@ -2524,7 +4012,15 @@
         "launch",
         "observability",
         "observability-slo"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "reliability-ops/postmortem-writing",
@@ -2532,7 +4028,15 @@
       "domain": "reliability-ops",
       "path": ".cursor/skills/reliability-ops/postmortem-writing/SKILL.md",
       "description": ">   Write blameless incident postmortems—timeline, impact, root cause, contributing   factors, and actionable follow-ups. Use after outages, SEV incidents, or   significant near-misses.   Triggers: \"postmortem\", \"incident review\", \"RCA\", \"blameless\", \"SEV\".",
+      "summary": ">   Write blameless incident postmortems—timeline, impact, root cause, contributing   factors, and actionable follow-ups. Use after outages, SEV incidents, or   significant near-misses.   Triggers: \"postmortem\", \"incident review\", \"RCA\", \"b",
       "triggers": [
+        "postmortem",
+        "incident review",
+        "RCA",
+        "blameless",
+        "SEV"
+      ],
+      "trigger_phrases": [
         "postmortem",
         "incident review",
         "RCA",
@@ -2552,7 +4056,15 @@
         "launch",
         "observability",
         "postmortem-writing"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "reliability-ops/serverless-debugging",
@@ -2560,7 +4072,15 @@
       "domain": "reliability-ops",
       "path": ".cursor/skills/reliability-ops/serverless-debugging/SKILL.md",
       "description": "Debug serverless and edge functions—limited logs, cold starts, timeouts, env/config mismatches. Use for Lambda, Cloud Functions, Workers, Vercel/Netlify functions. Triggers: \"serverless\", \"Lambda\", \"edge function\", \"cold start\", \"function timeout\".",
+      "summary": "Debug serverless and edge functions—limited logs, cold starts, timeouts, env/config mismatches. Use for Lambda, Cloud Functions, Workers, Vercel/Netlify functions. Triggers: \"serverless\", \"Lambda\", \"edge function\", \"cold start\", \"function t",
       "triggers": [
+        "serverless",
+        "Lambda",
+        "edge function",
+        "cold start",
+        "function timeout"
+      ],
+      "trigger_phrases": [
         "serverless",
         "Lambda",
         "edge function",
@@ -2580,7 +4100,15 @@
         "launch",
         "observability",
         "serverless-debugging"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "reliability-ops/shipping-launch-checklist",
@@ -2588,7 +4116,15 @@
       "domain": "reliability-ops",
       "path": ".cursor/skills/reliability-ops/shipping-launch-checklist/SKILL.md",
       "description": ">   Pre-launch and rollout checklist—feature flags, thresholds, rollback, monitoring,   and comms. Use before production releases or risky deploys.   Triggers: \"launch\", \"ship to prod\", \"rollout\", \"release checklist\", \"go live\".",
+      "summary": ">   Pre-launch and rollout checklist—feature flags, thresholds, rollback, monitoring,   and comms. Use before production releases or risky deploys.   Triggers: \"launch\", \"ship to prod\", \"rollout\", \"release checklist\", \"go live\".",
       "triggers": [
+        "launch",
+        "ship to prod",
+        "rollout",
+        "release checklist",
+        "go live"
+      ],
+      "trigger_phrases": [
         "launch",
         "ship to prod",
         "rollout",
@@ -2608,7 +4144,15 @@
         "launch",
         "observability",
         "shipping-launch-checklist"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "security-appsec/api-security-testing",
@@ -2616,7 +4160,15 @@
       "domain": "security-appsec",
       "path": ".cursor/skills/security-appsec/api-security-testing/SKILL.md",
       "description": ">   Security testing checklist for HTTP APIs—authn/z, input validation, rate limits,   sensitive data exposure, and common OWASP API issues. Use when reviewing or   testing REST/GraphQL endpoints before release.   Triggers: \"API security\", \"pen test API\", \"OWASP API\", \"auth test\", \"security test\".",
+      "summary": ">   Security testing checklist for HTTP APIs—authn/z, input validation, rate limits,   sensitive data exposure, and common OWASP API issues. Use when reviewing or   testing REST/GraphQL endpoints before release.   Triggers: \"API security\", ",
       "triggers": [
+        "API security",
+        "pen test API",
+        "OWASP API",
+        "auth test",
+        "security test"
+      ],
+      "trigger_phrases": [
         "API security",
         "pen test API",
         "OWASP API",
@@ -2635,7 +4187,15 @@
         "api",
         "audit",
         "api-security-testing"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "security-appsec/secure-api-design",
@@ -2643,7 +4203,15 @@
       "domain": "security-appsec",
       "path": ".cursor/skills/security-appsec/secure-api-design/SKILL.md",
       "description": ">   Design and implement secure APIs—authentication patterns, authorization models,   input validation, secrets handling, and safe defaults. Use when designing new   endpoints, auth flows, or reviewing API contracts.   Triggers: \"secure API\", \"auth design\", \"JWT\", \"OAuth\", \"API best practices\".",
+      "summary": ">   Design and implement secure APIs—authentication patterns, authorization models,   input validation, secrets handling, and safe defaults. Use when designing new   endpoints, auth flows, or reviewing API contracts.   Triggers: \"secure API",
       "triggers": [
+        "secure API",
+        "auth design",
+        "JWT",
+        "OAuth",
+        "API best practices"
+      ],
+      "trigger_phrases": [
         "secure API",
         "auth design",
         "JWT",
@@ -2662,7 +4230,15 @@
         "api",
         "audit",
         "secure-api-design"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "security-appsec/skill-supply-chain-audit",
@@ -2670,7 +4246,14 @@
       "domain": "security-appsec",
       "path": ".cursor/skills/security-appsec/skill-supply-chain-audit/SKILL.md",
       "description": ">   Audit third-party agent skills before install—metadata, triggers, scripts,   network/exfil patterns, and overlap with existing skills. Use before importing   skills from external catalogs or vendoring new SKILL.md files.   Triggers: \"audit skill\", \"import skill\", \"skill security\", \"third-party skill\".",
+      "summary": ">   Audit third-party agent skills before install—metadata, triggers, scripts,   network/exfil patterns, and overlap with existing skills. Use before importing   skills from external catalogs or vendoring new SKILL.md files.   Triggers: \"au",
       "triggers": [
+        "audit skill",
+        "import skill",
+        "skill security",
+        "third-party skill"
+      ],
+      "trigger_phrases": [
         "audit skill",
         "import skill",
         "skill security",
@@ -2688,7 +4271,15 @@
         "api",
         "audit",
         "skill-supply-chain-audit"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "core",
+      "quality_score": null
     },
     {
       "id": "visualization/data-viz-storytelling-healy",
@@ -2696,7 +4287,9 @@
       "domain": "visualization",
       "path": ".cursor/skills/visualization/data-viz-storytelling-healy/SKILL.md",
       "description": ">   Chọn đúng biểu đồ, kể chuyện với số liệu, và tránh误导 — dựa trên nguyên tắc   từ Kieran Healy (Data Visualization, Princeton 2019) và taxonomy từ AntV   chart-visualization-skills. Dùng khi cần quyết định loại chart, trình bày insight   cho stakeholder, hoặc kiểm tra xem figure có gây hiểu lầm không. Để vẽ Python   thực tế, chuyển sang matplotlib / seaborn / scientific-visualization.",
+      "summary": ">   Chọn đúng biểu đồ, kể chuyện với số liệu, và tránh误导 — dựa trên nguyên tắc   từ Kieran Healy (Data Visualization, Princeton 2019) và taxonomy từ AntV   chart-visualization-skills. Dùng khi cần quyết định loại chart, trình bày insight   ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2708,7 +4301,15 @@
         "viz",
         "charts",
         "data-viz-storytelling-healy"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "visualization/infographics",
@@ -2716,7 +4317,9 @@
       "domain": "visualization",
       "path": ".cursor/skills/visualization/infographics/SKILL.md",
       "description": "Create professional infographics using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Integrates research-lookup and web search for accurate data. Supports 10 infographic types, 8 industry styles, and colorblind-safe palettes.",
+      "summary": "Create professional infographics using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Integrates research-lookup and web search for accurate data. Supports 10 infographic types, 8 industry styles, ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2728,7 +4331,15 @@
         "viz",
         "charts",
         "infographics"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "visualization/matplotlib",
@@ -2736,7 +4347,9 @@
       "domain": "visualization",
       "path": ".cursor/skills/visualization/matplotlib/SKILL.md",
       "description": "Low-level plotting library for full customization. Use when you need fine-grained control over every plot element, creating novel plot types, or integrating with specific scientific workflows. Export to PNG/PDF/SVG for publication. For quick statistical plots use seaborn; for interactive plots use plotly; for publication-ready multi-panel figures with journal styling, use scientific-visualization.",
+      "summary": "Low-level plotting library for full customization. Use when you need fine-grained control over every plot element, creating novel plot types, or integrating with specific scientific workflows. Export to PNG/PDF/SVG for publication. For quic",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2748,7 +4361,15 @@
         "viz",
         "charts",
         "matplotlib"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "visualization/scientific-visualization",
@@ -2756,7 +4377,9 @@
       "domain": "visualization",
       "path": ".cursor/skills/visualization/scientific-visualization/SKILL.md",
       "description": "Meta-skill for publication-ready figures. Use when creating journal submission figures requiring multi-panel layouts, significance annotations, error bars, colorblind-safe palettes, and specific journal formatting (Nature, Science, Cell). Orchestrates matplotlib/seaborn/plotly with publication styles. For quick exploration use seaborn or plotly directly.",
+      "summary": "Meta-skill for publication-ready figures. Use when creating journal submission figures requiring multi-panel layouts, significance annotations, error bars, colorblind-safe palettes, and specific journal formatting (Nature, Science, Cell). O",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2768,7 +4391,15 @@
         "viz",
         "charts",
         "scientific-visualization"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "visualization/seaborn",
@@ -2776,7 +4407,9 @@
       "domain": "visualization",
       "path": ".cursor/skills/visualization/seaborn/SKILL.md",
       "description": "Statistical visualization with pandas integration. Use for quick exploration of distributions, relationships, and categorical comparisons with attractive defaults. Best for box plots, violin plots, pair plots, heatmaps. Built on matplotlib. For interactive plots use plotly; for publication styling use scientific-visualization.",
+      "summary": "Statistical visualization with pandas integration. Use for quick exploration of distributions, relationships, and categorical comparisons with attractive defaults. Best for box plots, violin plots, pair plots, heatmaps. Built on matplotlib.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2788,7 +4421,15 @@
         "viz",
         "charts",
         "seaborn"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "voltagent",
@@ -2796,7 +4437,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/SKILL.md",
       "description": ">-   Cursor skills converted from VoltAgent awesome-claude-code-subagents (DS/ML/AI/   research, product, orchestration). Use when you want role-based playbooks aligned   with data science and stakeholder workflows.",
+      "summary": ">-   Cursor skills converted from VoltAgent awesome-claude-code-subagents (DS/ML/AI/   research, product, orchestration). Use when you want role-based playbooks aligned   with data science and stakeholder workflows.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2809,7 +4452,15 @@
         "subagent",
         "roles",
         "voltagent-subagents"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/business-product/business-analyst",
@@ -2817,7 +4468,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/business-product/business-analyst/SKILL.md",
       "description": "Use when analyzing business processes, gathering requirements from stakeholders, or identifying process improvement opportunities to drive operational efficiency and measurable business value.",
+      "summary": "Use when analyzing business processes, gathering requirements from stakeholders, or identifying process improvement opportunities to drive operational efficiency and measurable business value.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2830,7 +4483,15 @@
         "subagent",
         "roles",
         "business-analyst"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/business-product/customer-success-manager",
@@ -2838,7 +4499,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/business-product/customer-success-manager/SKILL.md",
       "description": "Use this agent when you need to assess customer health, develop retention strategies, identify upsell opportunities, or maximize customer lifetime value. Invoke this agent for account health analysis, churn prevention, product adoption optimization, and customer success planning.",
+      "summary": "Use this agent when you need to assess customer health, develop retention strategies, identify upsell opportunities, or maximize customer lifetime value. Invoke this agent for account health analysis, churn prevention, product adoption opti",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2851,7 +4514,15 @@
         "subagent",
         "roles",
         "customer-success-manager"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/business-product/product-manager",
@@ -2859,7 +4530,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/business-product/product-manager/SKILL.md",
       "description": "Use this agent when you need to make product strategy decisions, prioritize features, or define roadmap plans based on user needs and business goals.",
+      "summary": "Use this agent when you need to make product strategy decisions, prioritize features, or define roadmap plans based on user needs and business goals.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2872,7 +4545,15 @@
         "subagent",
         "roles",
         "product-manager"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/business-product/project-manager",
@@ -2880,7 +4561,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/business-product/project-manager/SKILL.md",
       "description": "Use this agent when you need to establish project plans, track execution progress, manage risks, control budget/schedule, and coordinate stakeholders across complex initiatives.",
+      "summary": "Use this agent when you need to establish project plans, track execution progress, manage risks, control budget/schedule, and coordinate stakeholders across complex initiatives.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2893,7 +4576,15 @@
         "subagent",
         "roles",
         "project-manager"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/business-product/scrum-master",
@@ -2901,7 +4592,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/business-product/scrum-master/SKILL.md",
       "description": "Use when teams need facilitation, process optimization, velocity improvement, or agile ceremony management\\u2014especially for sprint planning, retrospectives, impediment removal, and scaling agile practices across multiple teams.",
+      "summary": "Use when teams need facilitation, process optimization, velocity improvement, or agile ceremony management\\u2014especially for sprint planning, retrospectives, impediment removal, and scaling agile practices across multiple teams.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2914,7 +4607,15 @@
         "subagent",
         "roles",
         "scrum-master"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/business-product/technical-writer",
@@ -2922,7 +4623,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/business-product/technical-writer/SKILL.md",
       "description": "Use this agent when you need to create, improve, or maintain technical documentation including API references, user guides, SDK documentation, and getting-started guides.",
+      "summary": "Use this agent when you need to create, improve, or maintain technical documentation including API references, user guides, SDK documentation, and getting-started guides.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2935,7 +4638,15 @@
         "subagent",
         "roles",
         "technical-writer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/business-product/ux-researcher",
@@ -2943,7 +4654,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/business-product/ux-researcher/SKILL.md",
       "description": "Use this agent when you need to conduct user research, analyze user behavior, or generate actionable insights to validate design decisions and uncover user needs. Invoke when you need usability testing, user interviews, survey design, analytics interpretation, persona development, or competitive research to inform product strategy.",
+      "summary": "Use this agent when you need to conduct user research, analyze user behavior, or generate actionable insights to validate design decisions and uncover user needs. Invoke when you need usability testing, user interviews, survey design, analy",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2956,7 +4669,15 @@
         "subagent",
         "roles",
         "ux-researcher"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/ai-engineer",
@@ -2964,7 +4685,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/ai-engineer/SKILL.md",
       "description": "Use this agent when architecting, implementing, or optimizing end-to-end AI systems\\u2014from model selection and training pipelines to production deployment and monitoring.",
+      "summary": "Use this agent when architecting, implementing, or optimizing end-to-end AI systems\\u2014from model selection and training pipelines to production deployment and monitoring.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2977,7 +4700,15 @@
         "subagent",
         "roles",
         "ai-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/data-analyst",
@@ -2985,7 +4716,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/data-analyst/SKILL.md",
       "description": "Use when you need to extract insights from business data, create dashboards and reports, or perform statistical analysis to support decision-making.",
+      "summary": "Use when you need to extract insights from business data, create dashboards and reports, or perform statistical analysis to support decision-making.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -2998,7 +4731,15 @@
         "subagent",
         "roles",
         "data-analyst"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/data-engineer",
@@ -3006,7 +4747,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/data-engineer/SKILL.md",
       "description": "Use this agent when you need to design, build, or optimize data pipelines, ETL/ELT processes, and data infrastructure. Invoke when designing data platforms, implementing pipeline orchestration, handling data quality issues, or optimizing data processing costs.",
+      "summary": "Use this agent when you need to design, build, or optimize data pipelines, ETL/ELT processes, and data infrastructure. Invoke when designing data platforms, implementing pipeline orchestration, handling data quality issues, or optimizing da",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3019,7 +4762,15 @@
         "subagent",
         "roles",
         "data-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/data-scientist",
@@ -3027,7 +4778,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/data-scientist/SKILL.md",
       "description": "Use this agent when you need to analyze data patterns, build predictive models, or extract statistical insights from datasets. Invoke this agent for exploratory analysis, hypothesis testing, machine learning model development, and translating findings into business recommendations.",
+      "summary": "Use this agent when you need to analyze data patterns, build predictive models, or extract statistical insights from datasets. Invoke this agent for exploratory analysis, hypothesis testing, machine learning model development, and translati",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3040,7 +4793,15 @@
         "subagent",
         "roles",
         "data-scientist"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/database-optimizer",
@@ -3048,7 +4809,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/database-optimizer/SKILL.md",
       "description": "Use this agent when you need to analyze slow queries, optimize database performance across multiple systems, or implement indexing strategies to improve query execution.",
+      "summary": "Use this agent when you need to analyze slow queries, optimize database performance across multiple systems, or implement indexing strategies to improve query execution.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3061,7 +4824,15 @@
         "subagent",
         "roles",
         "database-optimizer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/llm-architect",
@@ -3069,7 +4840,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/llm-architect/SKILL.md",
       "description": "Use when designing LLM systems for production, implementing fine-tuning or RAG architectures, optimizing inference serving infrastructure, or managing multi-model deployments.",
+      "summary": "Use when designing LLM systems for production, implementing fine-tuning or RAG architectures, optimizing inference serving infrastructure, or managing multi-model deployments.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3082,7 +4855,15 @@
         "subagent",
         "roles",
         "llm-architect"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/machine-learning-engineer",
@@ -3090,7 +4871,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/machine-learning-engineer/SKILL.md",
       "description": "Use this agent when you need to deploy, optimize, or serve machine learning models at scale in production environments.",
+      "summary": "Use this agent when you need to deploy, optimize, or serve machine learning models at scale in production environments.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3103,7 +4886,15 @@
         "subagent",
         "roles",
         "machine-learning-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/ml-engineer",
@@ -3111,7 +4902,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/ml-engineer/SKILL.md",
       "description": "Use this agent when building production ML systems requiring model training pipelines, model serving infrastructure, performance optimization, and automated retraining.",
+      "summary": "Use this agent when building production ML systems requiring model training pipelines, model serving infrastructure, performance optimization, and automated retraining.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3124,7 +4917,15 @@
         "subagent",
         "roles",
         "ml-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/mlops-engineer",
@@ -3132,7 +4933,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/mlops-engineer/SKILL.md",
       "description": "Use this agent when you need to design and implement ML infrastructure, set up CI/CD for machine learning models, establish model versioning systems, or optimize ML platforms for reliability and automation. Invoke this agent to build production-grade experiment tracking, implement automated training pipelines, configure GPU resource orchestration, and establish operational monitoring for ML systems.",
+      "summary": "Use this agent when you need to design and implement ML infrastructure, set up CI/CD for machine learning models, establish model versioning systems, or optimize ML platforms for reliability and automation. Invoke this agent to build produc",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3145,7 +4948,15 @@
         "subagent",
         "roles",
         "mlops-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/nlp-engineer",
@@ -3153,7 +4964,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/nlp-engineer/SKILL.md",
       "description": "Use when building production NLP systems, implementing text processing pipelines, developing language models, or solving domain-specific NLP tasks like named entity recognition, sentiment analysis, or machine translation.",
+      "summary": "Use when building production NLP systems, implementing text processing pipelines, developing language models, or solving domain-specific NLP tasks like named entity recognition, sentiment analysis, or machine translation.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3166,7 +4979,15 @@
         "subagent",
         "roles",
         "nlp-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/postgres-pro",
@@ -3174,7 +4995,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/postgres-pro/SKILL.md",
       "description": "Use when you need to optimize PostgreSQL performance, design high-availability replication, or troubleshoot database issues at scale. Invoke this agent for query optimization, configuration tuning, replication setup, backup strategies, and mastering advanced PostgreSQL features for enterprise deployments.",
+      "summary": "Use when you need to optimize PostgreSQL performance, design high-availability replication, or troubleshoot database issues at scale. Invoke this agent for query optimization, configuration tuning, replication setup, backup strategies, and ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3187,7 +5010,15 @@
         "subagent",
         "roles",
         "postgres-pro"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/prompt-engineer",
@@ -3195,7 +5026,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/prompt-engineer/SKILL.md",
       "description": "Use this agent when you need to design, optimize, test, or evaluate prompts for large language models in production systems.",
+      "summary": "Use this agent when you need to design, optimize, test, or evaluate prompts for large language models in production systems.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3208,7 +5041,15 @@
         "subagent",
         "roles",
         "prompt-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/data-ai/reinforcement-learning-engineer",
@@ -3216,7 +5057,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/data-ai/reinforcement-learning-engineer/SKILL.md",
       "description": "Use when designing RL environments, training agents with reward optimization, implementing policy gradient methods, or deploying decision-making systems for robotics, gaming, and autonomous operations.",
+      "summary": "Use when designing RL environments, training agents with reward optimization, implementing policy gradient methods, or deploying decision-making systems for robotics, gaming, and autonomous operations.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3229,7 +5072,15 @@
         "subagent",
         "roles",
         "reinforcement-learning-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/dev-workflow/documentation-engineer",
@@ -3237,7 +5088,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/dev-workflow/documentation-engineer/SKILL.md",
       "description": "Use this agent when you need to create, architect, or overhaul comprehensive documentation systems including API docs, tutorials, guides, and developer-friendly content that keeps pace with code changes.",
+      "summary": "Use this agent when you need to create, architect, or overhaul comprehensive documentation systems including API docs, tutorials, guides, and developer-friendly content that keeps pace with code changes.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3250,7 +5103,15 @@
         "subagent",
         "roles",
         "documentation-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/dev-workflow/git-workflow-manager",
@@ -3258,7 +5119,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/dev-workflow/git-workflow-manager/SKILL.md",
       "description": "Use this agent when you need to design, establish, or optimize Git workflows, branching strategies, and merge management for a project or team.",
+      "summary": "Use this agent when you need to design, establish, or optimize Git workflows, branching strategies, and merge management for a project or team.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3271,7 +5134,15 @@
         "subagent",
         "roles",
         "git-workflow-manager"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/dev-workflow/refactoring-specialist",
@@ -3279,7 +5150,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/dev-workflow/refactoring-specialist/SKILL.md",
       "description": "Use when you need to transform poorly structured, complex, or duplicated code into clean, maintainable systems while preserving all existing behavior.",
+      "summary": "Use when you need to transform poorly structured, complex, or duplicated code into clean, maintainable systems while preserving all existing behavior.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3292,7 +5165,15 @@
         "subagent",
         "roles",
         "refactoring-specialist"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/fintech-risk/fintech-engineer",
@@ -3300,7 +5181,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/fintech-risk/fintech-engineer/SKILL.md",
       "description": "Use when building payment systems, financial integrations, or compliance-heavy financial applications that require secure transaction processing, regulatory adherence, and high transaction accuracy.",
+      "summary": "Use when building payment systems, financial integrations, or compliance-heavy financial applications that require secure transaction processing, regulatory adherence, and high transaction accuracy.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3313,7 +5196,15 @@
         "subagent",
         "roles",
         "fintech-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/fintech-risk/healthcare-admin",
@@ -3321,7 +5212,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/fintech-risk/healthcare-admin/SKILL.md",
       "description": "Use when working on healthcare administration tasks including revenue cycle management, HIPAA/compliance auditing, medical coding (ICD-10, CPT, DRGs), CMS cost reports, payer contract analysis, quality improvement, clinical operations, health IT/interoperability, population health, and pharmacy benefits.",
+      "summary": "Use when working on healthcare administration tasks including revenue cycle management, HIPAA/compliance auditing, medical coding (ICD-10, CPT, DRGs), CMS cost reports, payer contract analysis, quality improvement, clinical operations, heal",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3334,7 +5227,15 @@
         "subagent",
         "roles",
         "healthcare-admin"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/fintech-risk/quant-analyst",
@@ -3342,7 +5243,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/fintech-risk/quant-analyst/SKILL.md",
       "description": "Use this agent when you need to develop quantitative trading strategies, build financial models with rigorous mathematical foundations, or conduct advanced risk analytics for derivatives and portfolios. Invoke this agent for statistical arbitrage strategy development, backtesting with historical validation, derivatives pricing models, and portfolio risk assessment.",
+      "summary": "Use this agent when you need to develop quantitative trading strategies, build financial models with rigorous mathematical foundations, or conduct advanced risk analytics for derivatives and portfolios. Invoke this agent for statistical arb",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3355,7 +5258,15 @@
         "subagent",
         "roles",
         "quant-analyst"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/fintech-risk/risk-manager",
@@ -3363,7 +5274,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/fintech-risk/risk-manager/SKILL.md",
       "description": "Use this agent when you need to identify, quantify, and mitigate enterprise-level risks across financial, operational, regulatory, and strategic domains. Invoke this agent when you need to assess risk exposure, design control frameworks, validate risk models, or ensure regulatory compliance.",
+      "summary": "Use this agent when you need to identify, quantify, and mitigate enterprise-level risks across financial, operational, regulatory, and strategic domains. Invoke this agent when you need to assess risk exposure, design control frameworks, va",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3376,7 +5289,15 @@
         "subagent",
         "roles",
         "risk-manager"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/infra/deployment-engineer",
@@ -3384,7 +5305,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/infra/deployment-engineer/SKILL.md",
       "description": "Use this agent when designing, building, or optimizing CI/CD pipelines and deployment automation strategies.",
+      "summary": "Use this agent when designing, building, or optimizing CI/CD pipelines and deployment automation strategies.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3397,7 +5320,15 @@
         "subagent",
         "roles",
         "deployment-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/languages/python-pro",
@@ -3405,7 +5336,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/languages/python-pro/SKILL.md",
       "description": "Use this agent when you need to build type-safe, production-ready Python code for web APIs, system utilities, or complex applications requiring modern async patterns and extensive type coverage.",
+      "summary": "Use this agent when you need to build type-safe, production-ready Python code for web APIs, system utilities, or complex applications requiring modern async patterns and extensive type coverage.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3418,7 +5351,15 @@
         "subagent",
         "roles",
         "python-pro"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/languages/sql-pro",
@@ -3426,7 +5367,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/languages/sql-pro/SKILL.md",
       "description": "Use this agent when you need to optimize complex SQL queries, design efficient database schemas, or solve performance issues across PostgreSQL, MySQL, SQL Server, and Oracle requiring advanced query optimization, index strategies, or data warehouse patterns.",
+      "summary": "Use this agent when you need to optimize complex SQL queries, design efficient database schemas, or solve performance issues across PostgreSQL, MySQL, SQL Server, and Oracle requiring advanced query optimization, index strategies, or data w",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3439,7 +5382,15 @@
         "subagent",
         "roles",
         "sql-pro"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/orchestration/context-manager",
@@ -3447,7 +5398,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/orchestration/context-manager/SKILL.md",
       "description": "Use for managing shared state, information retrieval, and data synchronization when multiple agents need coordinated access to context and metadata.",
+      "summary": "Use for managing shared state, information retrieval, and data synchronization when multiple agents need coordinated access to context and metadata.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3460,7 +5413,15 @@
         "subagent",
         "roles",
         "context-manager"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/orchestration/error-coordinator",
@@ -3468,7 +5429,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/orchestration/error-coordinator/SKILL.md",
       "description": "Use this agent when distributed system errors occur and need coordinated handling across multiple components, or when you need to implement comprehensive error recovery strategies with automated failure detection and cascade prevention.",
+      "summary": "Use this agent when distributed system errors occur and need coordinated handling across multiple components, or when you need to implement comprehensive error recovery strategies with automated failure detection and cascade prevention.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3481,7 +5444,15 @@
         "subagent",
         "roles",
         "error-coordinator"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/orchestration/knowledge-synthesizer",
@@ -3489,7 +5460,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/orchestration/knowledge-synthesizer/SKILL.md",
       "description": "Use when you need to extract actionable patterns from agent interactions, synthesize insights across multiple workflows, and enable organizational learning from collective experience.",
+      "summary": "Use when you need to extract actionable patterns from agent interactions, synthesize insights across multiple workflows, and enable organizational learning from collective experience.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3502,7 +5475,15 @@
         "subagent",
         "roles",
         "knowledge-synthesizer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/orchestration/multi-agent-coordinator",
@@ -3510,7 +5491,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/orchestration/multi-agent-coordinator/SKILL.md",
       "description": "Use when coordinating multiple concurrent agents that need to communicate, share state, synchronize work, and handle distributed failures across a system.",
+      "summary": "Use when coordinating multiple concurrent agents that need to communicate, share state, synchronize work, and handle distributed failures across a system.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3523,7 +5506,15 @@
         "subagent",
         "roles",
         "multi-agent-coordinator"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/orchestration/task-distributor",
@@ -3531,7 +5522,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/orchestration/task-distributor/SKILL.md",
       "description": "Use when distributing tasks across multiple agents or workers, managing queues, and balancing workloads to maximize throughput while respecting priorities and deadlines.",
+      "summary": "Use when distributing tasks across multiple agents or workers, managing queues, and balancing workloads to maximize throughput while respecting priorities and deadlines.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3544,7 +5537,15 @@
         "subagent",
         "roles",
         "task-distributor"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/quality-engineering/code-reviewer",
@@ -3552,7 +5553,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/quality-engineering/code-reviewer/SKILL.md",
       "description": "Use this agent when you need to conduct comprehensive code reviews focusing on code quality, security vulnerabilities, and best practices.",
+      "summary": "Use this agent when you need to conduct comprehensive code reviews focusing on code quality, security vulnerabilities, and best practices.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3565,7 +5568,15 @@
         "subagent",
         "roles",
         "code-reviewer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/quality-engineering/debugger",
@@ -3573,7 +5584,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/quality-engineering/debugger/SKILL.md",
       "description": "Use this agent when you need to diagnose and fix bugs, identify root causes of failures, or analyze error logs and stack traces to resolve issues.",
+      "summary": "Use this agent when you need to diagnose and fix bugs, identify root causes of failures, or analyze error logs and stack traces to resolve issues.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3586,7 +5599,15 @@
         "subagent",
         "roles",
         "debugger"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/quality-engineering/performance-engineer",
@@ -3594,7 +5615,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/quality-engineering/performance-engineer/SKILL.md",
       "description": "Use this agent when you need to identify and eliminate performance bottlenecks in applications, databases, or infrastructure systems, and when baseline performance metrics need improvement.",
+      "summary": "Use this agent when you need to identify and eliminate performance bottlenecks in applications, databases, or infrastructure systems, and when baseline performance metrics need improvement.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3607,7 +5630,15 @@
         "subagent",
         "roles",
         "performance-engineer"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/quality-engineering/qa-expert",
@@ -3615,7 +5646,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/quality-engineering/qa-expert/SKILL.md",
       "description": "Use this agent when you need comprehensive quality assurance strategy, test planning across the entire development cycle, or quality metrics analysis to improve overall software quality.",
+      "summary": "Use this agent when you need comprehensive quality assurance strategy, test planning across the entire development cycle, or quality metrics analysis to improve overall software quality.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3628,7 +5661,15 @@
         "subagent",
         "roles",
         "qa-expert"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/research-analysis/competitive-analyst",
@@ -3636,7 +5677,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/research-analysis/competitive-analyst/SKILL.md",
       "description": "Use when you need to analyze direct and indirect competitors, benchmark against market leaders, or develop strategies to strengthen competitive positioning and market advantage.",
+      "summary": "Use when you need to analyze direct and indirect competitors, benchmark against market leaders, or develop strategies to strengthen competitive positioning and market advantage.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3649,7 +5692,15 @@
         "subagent",
         "roles",
         "competitive-analyst"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/research-analysis/data-researcher",
@@ -3657,7 +5708,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/research-analysis/data-researcher/SKILL.md",
       "description": "Use this agent when you need to discover, collect, and validate data from multiple sources to fuel analysis and decision-making. Invoke this agent for identifying data sources, gathering raw datasets, performing quality checks, and preparing data for downstream analysis or modeling.",
+      "summary": "Use this agent when you need to discover, collect, and validate data from multiple sources to fuel analysis and decision-making. Invoke this agent for identifying data sources, gathering raw datasets, performing quality checks, and preparin",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3670,7 +5723,15 @@
         "subagent",
         "roles",
         "data-researcher"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/research-analysis/market-researcher",
@@ -3678,7 +5739,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/research-analysis/market-researcher/SKILL.md",
       "description": "Use this agent when you need to analyze markets, understand consumer behavior, assess competitive landscapes, and size opportunities to inform business strategy and market entry decisions.",
+      "summary": "Use this agent when you need to analyze markets, understand consumer behavior, assess competitive landscapes, and size opportunities to inform business strategy and market entry decisions.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3691,7 +5754,15 @@
         "subagent",
         "roles",
         "market-researcher"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/research-analysis/project-idea-validator",
@@ -3699,7 +5770,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/research-analysis/project-idea-validator/SKILL.md",
       "description": "Use this agent when you need an idea pressure-tested with brutal honesty, competitor teardown, market validation, and clear go/no-go guidance before building.",
+      "summary": "Use this agent when you need an idea pressure-tested with brutal honesty, competitor teardown, market validation, and clear go/no-go guidance before building.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3712,7 +5785,15 @@
         "subagent",
         "roles",
         "project-idea-validator"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/research-analysis/research-analyst",
@@ -3720,7 +5801,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/research-analysis/research-analyst/SKILL.md",
       "description": "Use this agent when you need comprehensive research across multiple sources with synthesis of findings into actionable insights, trend identification, and detailed reporting.",
+      "summary": "Use this agent when you need comprehensive research across multiple sources with synthesis of findings into actionable insights, trend identification, and detailed reporting.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3733,7 +5816,15 @@
         "subagent",
         "roles",
         "research-analyst"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/research-analysis/scientific-literature-researcher",
@@ -3741,7 +5832,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/research-analysis/scientific-literature-researcher/SKILL.md",
       "description": "Use when you need to search scientific literature and retrieve structured experimental data from published studies. Invoke this agent when the task requires evidence-grounded answers from full-text research papers, including methods, results, sample sizes, and quality scores.",
+      "summary": "Use when you need to search scientific literature and retrieve structured experimental data from published studies. Invoke this agent when the task requires evidence-grounded answers from full-text research papers, including methods, result",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3754,7 +5847,15 @@
         "subagent",
         "roles",
         "scientific-literature-researcher"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/research-analysis/search-specialist",
@@ -3762,7 +5863,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/research-analysis/search-specialist/SKILL.md",
       "description": "Use when you need to find specific information across multiple sources using advanced search strategies, query optimization, and targeted information retrieval. Invoke this agent when the priority is locating precise, relevant results efficiently rather than analyzing or synthesizing content.",
+      "summary": "Use when you need to find specific information across multiple sources using advanced search strategies, query optimization, and targeted information retrieval. Invoke this agent when the priority is locating precise, relevant results effic",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3775,7 +5878,15 @@
         "subagent",
         "roles",
         "search-specialist"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "voltagent/research-analysis/trend-analyst",
@@ -3783,7 +5894,9 @@
       "domain": "voltagent",
       "path": ".cursor/skills/voltagent/research-analysis/trend-analyst/SKILL.md",
       "description": "Use when analyzing emerging patterns, predicting industry shifts, or developing future scenarios to inform strategic planning and competitive positioning.",
+      "summary": "Use when analyzing emerging patterns, predicting industry shifts, or developing future scenarios to inform strategic planning and competitive positioning.",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3796,7 +5909,15 @@
         "subagent",
         "roles",
         "trend-analyst"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "imported-pack",
+      "related": [],
+      "tier": "imported",
+      "quality_score": null
     },
     {
       "id": "writing-docs/docx",
@@ -3804,7 +5925,9 @@
       "domain": "writing-docs",
       "path": ".cursor/skills/writing-docs/docx/SKILL.md",
       "description": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting or reorganizing content from .docx files, inserting or replacing images in documents, performing find-and-replace in Word files, working with tracked changes or comments, ",
+      "summary": "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of 'Word doc', 'word document', '.docx', or requests to produce professional documents with formatting l",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3816,7 +5939,15 @@
         "docs",
         "writing",
         "docx"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "writing-docs/pdf",
@@ -3824,7 +5955,9 @@
       "domain": "writing-docs",
       "path": ".cursor/skills/writing-docs/pdf/SKILL.md",
       "description": "Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.",
+      "summary": "Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating ",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3836,7 +5969,15 @@
         "docs",
         "writing",
         "pdf"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "writing-docs/pptx",
@@ -3844,7 +5985,15 @@
       "domain": "writing-docs",
       "path": ".cursor/skills/writing-docs/pptx/SKILL.md",
       "description": ">   Create and edit PowerPoint presentations (.pptx)—slides, layouts, speaker notes,   and export. Use when the deliverable is a deck for stakeholders, workshops,   or model readouts. Complements docx/pdf/xlsx skills.   Triggers: \"PowerPoint\", \"pptx\", \"slides\", \"deck\", \"presentation\".",
+      "summary": ">   Create and edit PowerPoint presentations (.pptx)—slides, layouts, speaker notes,   and export. Use when the deliverable is a deck for stakeholders, workshops,   or model readouts. Complements docx/pdf/xlsx skills.   Triggers: \"PowerPoin",
       "triggers": [
+        "PowerPoint",
+        "pptx",
+        "slides",
+        "deck",
+        "presentation"
+      ],
+      "trigger_phrases": [
         "PowerPoint",
         "pptx",
         "slides",
@@ -3862,7 +6011,15 @@
         "docs",
         "writing",
         "pptx"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "writing-docs/prose-polish",
@@ -3870,7 +6027,15 @@
       "domain": "writing-docs",
       "path": ".cursor/skills/writing-docs/prose-polish/SKILL.md",
       "description": ">   Polish technical and stakeholder prose—clarity, tone, structure, and reducing   generic AI-writing patterns. Use for blog posts, knowledge-base pages, READMEs, exec   summaries, and user-facing copy before publish.   Triggers: \"edit prose\", \"polish writing\", \"sounds like AI\", \"copy edit\", \"tone\".",
+      "summary": ">   Polish technical and stakeholder prose—clarity, tone, structure, and reducing   generic AI-writing patterns. Use for blog posts, knowledge-base pages, READMEs, exec   summaries, and user-facing copy before publish.   Triggers: \"edit pro",
       "triggers": [
+        "edit prose",
+        "polish writing",
+        "sounds like AI",
+        "copy edit",
+        "tone"
+      ],
+      "trigger_phrases": [
         "edit prose",
         "polish writing",
         "sounds like AI",
@@ -3888,7 +6053,15 @@
         "docs",
         "writing",
         "prose-polish"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "writing-docs/scientific-writing",
@@ -3896,7 +6069,9 @@
       "domain": "writing-docs",
       "path": ".cursor/skills/writing-docs/scientific-writing/SKILL.md",
       "description": "Core skill for the deep research and writing tool. Write scientific manuscripts in full paragraphs (never bullet points). Use two-stage process with (1) section outlines with key points using research-lookup then (2) convert to flowing prose. IMRAD structure, citations (APA/AMA/Vancouver), figures/tables, reporting guidelines (CONSORT/STROBE/PRISMA), for research papers and journal submissions.",
+      "summary": "Core skill for the deep research and writing tool. Write scientific manuscripts in full paragraphs (never bullet points). Use two-stage process with (1) section outlines with key points using research-lookup then (2) convert to flowing pros",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3908,7 +6083,15 @@
         "docs",
         "writing",
         "scientific-writing"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "writing-docs/sympy",
@@ -3916,7 +6099,9 @@
       "domain": "writing-docs",
       "path": ".cursor/skills/writing-docs/sympy/SKILL.md",
       "description": "Use this skill when working with symbolic mathematics in Python. This skill should be used for symbolic computation tasks including solving equations algebraically, performing calculus operations (derivatives, integrals, limits), manipulating algebraic expressions, working with matrices symbolically, physics calculations, number theory problems, geometry computations, and generating executable code from mathematical expressions. Apply this skill when the user needs exact symbolic results rather ",
+      "summary": "Use this skill when working with symbolic mathematics in Python. This skill should be used for symbolic computation tasks including solving equations algebraically, performing calculus operations (derivatives, integrals, limits), manipulati",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3928,7 +6113,15 @@
         "docs",
         "writing",
         "sympy"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     },
     {
       "id": "writing-docs/xlsx",
@@ -3936,7 +6129,9 @@
       "domain": "writing-docs",
       "path": ".cursor/skills/writing-docs/xlsx/SKILL.md",
       "description": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatting, charting, cleaning messy data); create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger especially when the user references a spreadsheet file by name or path — even casually (like \\\"the xlsx in m",
+      "summary": "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file (e.g., adding columns, computing formulas, formatt",
       "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",
@@ -3948,7 +6143,15 @@
         "docs",
         "writing",
         "xlsx"
-      ]
+      ],
+      "requires_tools": [],
+      "writes_files": [],
+      "network_access": "unknown",
+      "risk_reason": "",
+      "provenance": "awesome-agent-skill",
+      "related": [],
+      "tier": "community",
+      "quality_score": null
     }
   ]
 }

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -49,6 +49,21 @@ DOMAIN_TAGS: dict[str, list[str]] = {
 }
 
 
+def default_tier(domain: str) -> str:
+    """Coarse tiering for now; can be refined later."""
+    if domain in {"core-workflow", "ai-agent-systems", "reliability-ops", "security-appsec"}:
+        return "core"
+    if domain in {"gstack", "voltagent"}:
+        return "imported"
+    return "community"
+
+
+def default_provenance(domain: str) -> str:
+    if domain in {"gstack", "voltagent"}:
+        return "imported-pack"
+    return "awesome-agent-skill"
+
+
 def parse_frontmatter(text: str) -> dict[str, str]:
     if not text.startswith("---"):
         return {}
@@ -104,6 +119,8 @@ def collect_skills() -> list[dict]:
         tags = list(DOMAIN_TAGS.get(dom, [dom]))
         if name not in tags:
             tags.append(name)
+        triggers = extract_triggers(desc)
+        summary = desc[:240] if desc else ""
         entries.append(
             {
                 "id": rel,
@@ -111,12 +128,23 @@ def collect_skills() -> list[dict]:
                 "domain": dom,
                 "path": f".cursor/skills/{rel}/SKILL.md",
                 "description": desc[:500],
-                "triggers": extract_triggers(desc),
+                "summary": summary,
+                "triggers": triggers,
+                "trigger_phrases": triggers,
                 "risk": DOMAIN_RISK.get(dom, "low"),
                 "formats": ["cursor", "claude"],
                 "source": "awesome-agent-skill",
                 "license": "MIT",
                 "tags": tags[:8],
+                # v2 metadata — defaults; can be refined by other tooling
+                "requires_tools": [],
+                "writes_files": [],
+                "network_access": "unknown",
+                "risk_reason": "",
+                "provenance": default_provenance(dom),
+                "related": [],
+                "tier": default_tier(dom),
+                "quality_score": None,
             }
         )
     return entries
@@ -150,7 +178,7 @@ def validate_bundles(skills: list[dict]) -> list[str]:
 def build_payload(skills: list[dict]) -> dict:
     return {
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "schema_version": 1,
+        "schema_version": 2,
         "count": len(skills),
         "skills": skills,
     }

--- a/scripts/skillhub.py
+++ b/scripts/skillhub.py
@@ -225,6 +225,47 @@ def cmd_doctor(_: argparse.Namespace) -> int:
         )
         check("registry sync", r.returncode == 0, r.stderr.strip() or r.stdout.strip())
 
+        # Count drift checks: .cursor vs registry vs README badge vs metrics snapshot.
+        try:
+            data = load_registry()
+            registry_count = int(data.get("count", 0))
+        except Exception:
+            registry_count = -1
+
+        cursor_root = ROOT / ".cursor" / "skills"
+        cursor_count = len(list(cursor_root.rglob("SKILL.md"))) if cursor_root.exists() else -1
+        check(
+            "count: cursor vs registry",
+            cursor_count == registry_count and cursor_count >= 0,
+            f"cursor={cursor_count}, registry={registry_count}",
+        )
+
+        readme = ROOT / "README.md"
+        readme_count = None
+        if readme.exists():
+            m = re.search(r"skills-(\d+)-", readme.read_text(encoding="utf-8"))
+            if m:
+                readme_count = int(m.group(1))
+                check(
+                    "count: README badge vs registry",
+                    readme_count == registry_count,
+                    f"readme={readme_count}, registry={registry_count}",
+                )
+
+        metrics_path = ROOT / "docs" / "metrics" / "2026-05.md"
+        if metrics_path.exists():
+            m = re.search(
+                r"Cursor `SKILL\.md` files:\s*\*\*(\d+)\*\*",
+                metrics_path.read_text(encoding="utf-8"),
+            )
+            if m:
+                metrics_count = int(m.group(1))
+                check(
+                    "count: metrics vs registry",
+                    metrics_count == registry_count,
+                    f"metrics={metrics_count}, registry={registry_count}",
+                )
+
     for name in ("install-domain.sh", "install-bundle.sh", "install-skill.sh"):
         p = ROOT / "scripts" / "install" / name
         check(name, p.exists() and p.stat().st_mode & 0o111)


### PR DESCRIPTION
## Summary
- Nâng Wrote 178 skills to /Users/viet.tran1/Documents/CakeProjects/Credit Scoring Repos/awesome-agent-skill/registry/skills.json
Bundles validated against skills registry lên  và bổ sung metadata v2 cho từng skill (summary, trigger_phrases, tier, provenance, v.v.).
- Regenerate  với schema mới (178 skills hiện tại).
- Mở rộng  để kiểm tra count drift giữa , , badge README và snapshot metrics .

## Details
- Không thay đổi nội dung , chỉ metadata và health checks.
-  hiện báo FAIL rõ ràng khi số lượng skill ở README/metrics lệch so với registry, giúp maintainers cập nhật doc.

## Test plan
- Wrote 178 skills to /Users/viet.tran1/Documents/CakeProjects/Credit Scoring Repos/awesome-agent-skill/registry/skills.json
Bundles validated against skills registry
- Validated 178 Cursor skills and 272 Claude skills
- [ok] registry/skills.json
[ok] registry/bundles.json
[ok] registry sync — Registry OK (178 skills)
[ok] count: cursor vs registry — cursor=178, registry=178
[FAIL] count: README badge vs registry — readme=170, registry=178
[FAIL] count: metrics vs registry — metrics=173, registry=178
[ok] install-domain.sh
[ok] install-bundle.sh
[ok] install-skill.sh
[ok] validate-skills.py


Made with [Cursor](https://cursor.com)