### PR TITLE
SkillHub Phase 3: content conformance V2

### DIFF
--- a/.cursor/skills/core-workflow/spec-driven-development/SKILL.md
+++ b/.cursor/skills/core-workflow/spec-driven-development/SKILL.md
@@ -1,10 +1,19 @@
 ---
 name: spec-driven-development
+version: 2
 description: >
   Write a structured spec before significant implementation—objective, commands,
   boundaries, testing, and success criteria. Use when starting a feature, project,
   or multi-file change without a written spec.
-  Triggers: "write spec", "PRD", "requirements", "spec before code", "what are we building".
+triggers:
+  - "write spec"
+  - "PRD"
+  - "requirements"
+  - "spec before code"
+  - "what are we building"
+tools: []
+mutating: false
+priority: normal
 ---
 
 # Spec-driven development

--- a/docs/review-rubric.md
+++ b/docs/review-rubric.md
@@ -5,11 +5,14 @@ Use this rubric when reviewing new or updated skills.
 | Dimension | Pass | Fail |
 |-----------|------|------|
 | Naming | `name` matches folder; kebab-case; unique | Mismatch, duplicate, or vague name |
-| Triggers | Description includes `Triggers:` or clear `Use when` | Agent cannot tell when to invoke |
+| Triggers | Frontmatter has `triggers` list with realistic phrases | Agent cannot tell when to invoke |
 | Scope | Single workflow; clear non-goals | Kitchen-sink skill covering unrelated tasks |
 | Safety | No secrets/PII/internal URLs | Credential patterns, private tenant names |
-| Overlap | Distinct from nearby skills | Duplicates `core-workflow/*` or gstack/voltagent without reason |
-| Verification | Defines output or checks | No done condition |
+| Overlap (MECE) | Distinct from nearby skills; `Related Skills` lists neighbors | Duplicates `core-workflow/*` or gstack/voltagent without reason |
+| Contract | `## Contract` states what is guaranteed on success | Only describes topic, not outcome |
+| Phases | `## Phases` present with 2–7 clear stages | No sense of progression or order |
+| Output | `## Output Format` describes shape of answer/artifact | No done condition or output shape |
+| Anti-Patterns | `## Anti-Patterns` lists at least 2–3 failure modes to avoid | Skill silently does risky or out-of-scope work |
 | Size | Focused SKILL.md; refs in `reference.md` | Very long inline reference dumps |
 
 ## Scoring

--- a/docs/skill-writing-guide.md
+++ b/docs/skill-writing-guide.md
@@ -15,33 +15,83 @@ Guidance for authoring skills that agents can discover and follow reliably.
 ```yaml
 ---
 name: my-skill-name
+version: 1
 description: One sentence summary. Triggers: "phrase one", "phrase two".
+triggers:
+  - "phrase one"
+  - "phrase two"
+tools: []        # optional, list of MCP or CLI tools this skill calls
+mutating: false  # does this skill write files / change external systems?
+priority: normal # optional: normal | high | low
 ---
 ```
 
 - `name` must match the folder name (kebab-case)
-- Include `Triggers:` with quoted phrases for non-legacy domains
+- `version` should be bumped when behavior or contract changes
+- `triggers` should be an explicit list of phrases users or agents actually say
+- `tools` and `mutating` help agent routers decide when extra care is needed
 
-## Structure template
+## Structure template (Content Conformance V2)
 
-1. When to use
-2. When not to use
-3. Workflow (numbered)
-4. Output / acceptance criteria
-5. Related skills
+Every non-legacy skill should follow this structure:
+
+1. **Contract** — what this skill guarantees when it succeeds
+2. **When To Use**
+3. **When Not To Use**
+4. **Phases** — high-level stages of the workflow
+5. **Output Format** — shape of the final answer or artifact
+6. **Anti-Patterns** — what the skill must explicitly avoid
+7. **Related Skills** — pointers to adjacent skills or alternatives
+
+At minimum, include the following headings:
+
+```markdown
+## Contract
+## When To Use
+## When Not To Use
+## Phases
+## Output Format
+## Anti-Patterns
+## Related Skills
+```
 
 ## Examples
 
-### Good
+### Good (Content Conformance V2)
 
 ```markdown
-## Workflow
-1. Confirm target API surface and consumers
-2. Draft request/response examples including errors
-3. Run secure-api-design checklist for auth and validation
+## Contract
+Help the user produce a concrete API design proposal that is safe, reviewable, and ready for implementation.
+
+## When To Use
+- New or significantly changed HTTP/JSON API
+- Team needs alignment on request/response shapes and error handling
+
+## When Not To Use
+- Simple internal helper functions or private methods
+
+## Phases
+1. Clarify consumers and non-goals
+2. Sketch endpoints, request/response, and errors
+3. Run secure-api-design checklist
+4. Produce review-ready proposal
+
+## Output Format
+- Markdown section with:
+  - Table of endpoints
+  - Detailed request/response examples
+  - Auth and validation notes
+
+## Anti-Patterns
+- Do not invent undocumented auth schemes
+- Do not approve designs without error handling
+
+## Related Skills
+- `secure-api-design`
+- `deprecation-and-migration`
 ```
 
-Clear, ordered, verifiable.
+Clear contract, explicit phases, defined output, and concrete anti-patterns.
 
 ### Bad
 
@@ -74,6 +124,12 @@ When adapting from catalogs such as [obra/superpowers](https://github.com/obra/s
 - Record the decision in `EXTERNAL_SKILLS.md`
 - Rewrite wording; do not copy plugin hooks or bootstrap meta-skills
 - Prefer **merge** into an existing skill when overlap is high
+
+## Skill vs code
+
+- Deterministic operations (file layout, install plans, concrete commands) usually belong in **scripts/CLI**.
+- Judgment calls, routing between workflows, and failure-mode handling belong in **skills**.
+- When in doubt, keep the harness thin and the skill explicit about decisions and trade-offs.
 
 ## Before opening a PR
 

--- a/registry/quality.json
+++ b/registry/quality.json
@@ -1,43 +1,59 @@
 {
-  "generated_at": "2026-05-25T10:22:20Z",
+  "generated_at": "2026-05-27T13:05:37Z",
   "schema_version": 1,
-  "count": 173,
-  "average_score": 70,
-  "low_score_count": 3,
+  "count": 178,
+  "average_score": 43,
+  "low_score_count": 126,
   "skills": [
     {
       "id": "ai-agent-systems/agent-evaluation",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "ai-agent-systems/agent-tool-contracts",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "ai-agent-systems/context-window-management",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -45,12 +61,35 @@
       "issues": []
     },
     {
-      "id": "ai-agent-systems/mcp-builder",
-      "score": 83,
+      "id": "ai-agent-systems/dispatching-parallel-agents",
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
+        "has_examples": false,
+        "has_reference": false,
+        "risk_set": true
+      },
+      "issues": [
+        "low overall score"
+      ]
+    },
+    {
+      "id": "ai-agent-systems/mcp-builder",
+      "score": 50,
+      "checks": {
+        "description_min_80": true,
+        "has_triggers": true,
+        "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -59,25 +98,54 @@
     },
     {
       "id": "ai-agent-systems/mcp-ecosystem-optimizer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "ai-agent-systems/rag-systems",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
+        "has_reference": false,
+        "risk_set": true
+      },
+      "issues": [
+        "low overall score"
+      ]
+    },
+    {
+      "id": "ai-agent-systems/subagent-driven-development",
+      "score": 50,
+      "checks": {
+        "description_min_80": true,
+        "has_triggers": true,
+        "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
+        "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
@@ -85,11 +153,15 @@
     },
     {
       "id": "analysis-stats/shap",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -100,11 +172,15 @@
     },
     {
       "id": "analysis-stats/statistical-analysis",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -115,11 +191,15 @@
     },
     {
       "id": "analysis-stats/statsmodels",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -130,11 +210,15 @@
     },
     {
       "id": "architecture/system-mapping",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -143,11 +227,15 @@
     },
     {
       "id": "core-workflow/api-and-interface-design",
-      "score": 67,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": true,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
@@ -156,11 +244,15 @@
     },
     {
       "id": "core-workflow/architecture-decision-records",
-      "score": 100,
+      "score": 60,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -169,11 +261,15 @@
     },
     {
       "id": "core-workflow/clarify-underspecified",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -182,37 +278,53 @@
     },
     {
       "id": "core-workflow/code-simplification",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "core-workflow/deprecation-and-migration",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "core-workflow/design-smell-review",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -221,24 +333,34 @@
     },
     {
       "id": "core-workflow/doubt-driven-review",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "core-workflow/github-comment-triage",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -247,11 +369,15 @@
     },
     {
       "id": "core-workflow/idea-refine",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -260,24 +386,34 @@
     },
     {
       "id": "core-workflow/incremental-implementation",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "core-workflow/interview-me",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -286,11 +422,15 @@
     },
     {
       "id": "core-workflow/planning-and-task-breakdown",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -299,12 +439,35 @@
     },
     {
       "id": "core-workflow/receiving-code-review",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
+        "has_reference": false,
+        "risk_set": true
+      },
+      "issues": [
+        "low overall score"
+      ]
+    },
+    {
+      "id": "core-workflow/requesting-code-review",
+      "score": 50,
+      "checks": {
+        "description_min_80": true,
+        "has_triggers": true,
+        "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
+        "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
@@ -312,11 +475,15 @@
     },
     {
       "id": "core-workflow/source-driven-development",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -325,11 +492,15 @@
     },
     {
       "id": "core-workflow/spec-driven-development",
-      "score": 100,
+      "score": 60,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -337,12 +508,35 @@
       "issues": []
     },
     {
-      "id": "core-workflow/test-failure-triage",
-      "score": 83,
+      "id": "core-workflow/systematic-debugging",
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
+        "has_examples": false,
+        "has_reference": false,
+        "risk_set": true
+      },
+      "issues": [
+        "low overall score"
+      ]
+    },
+    {
+      "id": "core-workflow/test-failure-triage",
+      "score": 50,
+      "checks": {
+        "description_min_80": true,
+        "has_triggers": true,
+        "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -351,24 +545,34 @@
     },
     {
       "id": "core-workflow/test-first-development",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "core-workflow/verify-before-done",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -377,11 +581,15 @@
     },
     {
       "id": "core-workflow/work-access-handoff",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -390,11 +598,15 @@
     },
     {
       "id": "data-compute/dask",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -405,11 +617,15 @@
     },
     {
       "id": "data-compute/networkx",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -420,11 +636,15 @@
     },
     {
       "id": "data-compute/polars",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -435,11 +655,15 @@
     },
     {
       "id": "eda-research/exploratory-data-analysis",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -450,11 +674,15 @@
     },
     {
       "id": "eda-research/hypothesis-generation",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -465,11 +693,15 @@
     },
     {
       "id": "eda-research/umap-learn",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -480,24 +712,34 @@
     },
     {
       "id": "frontend-engineering/browser-testing-with-devtools",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "frontend-engineering/frontend-ui-accessibility",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": true,
         "risk_set": true
@@ -506,99 +748,134 @@
     },
     {
       "id": "frontend-engineering/frontend-ui-engineering",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "gstack",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/browser-qa/benchmark",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/browser-qa/benchmark-models",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/browser-qa/browse",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/browser-qa/canary",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/browser-qa/qa",
-      "score": 67,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": true,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -609,71 +886,95 @@
     },
     {
       "id": "gstack/browser-qa/qa-only",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/code-quality/codex",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/code-quality/health",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/code-quality/investigate",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/code-quality/review",
-      "score": 67,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": true,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -684,146 +985,195 @@
     },
     {
       "id": "gstack/context-memory/context-restore",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/context-memory/context-save",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/context-memory/learn",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/context-memory/setup-gbrain",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/context-memory/sync-gbrain",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/deploy-ship/document-release",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/deploy-ship/land-and-deploy",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/deploy-ship/landing-report",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/deploy-ship/setup-deploy",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/deploy-ship/ship",
-      "score": 67,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": true,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -834,41 +1184,55 @@
     },
     {
       "id": "gstack/design/design-consultation",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/design/design-html",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/design/design-review",
-      "score": 67,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": true,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -879,402 +1243,536 @@
     },
     {
       "id": "gstack/design/design-shotgun",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/plan-review/autoplan",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/plan-review/devex-review",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/plan-review/plan-ceo-review",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/plan-review/plan-design-review",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/plan-review/plan-devex-review",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/plan-review/plan-eng-review",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/plan-review/plan-tune",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/remote-agents/openclaw/gstack-openclaw-ceo-review",
-      "score": 50,
+      "score": 30,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/remote-agents/openclaw/gstack-openclaw-investigate",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/remote-agents/openclaw/gstack-openclaw-office-hours",
-      "score": 50,
+      "score": 30,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/remote-agents/openclaw/gstack-openclaw-retro",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/remote-agents/pair-agent",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/scrape/browser-skills/hackernews-frontpage",
-      "score": 50,
+      "score": 30,
       "checks": {
         "description_min_80": false,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
         "short description",
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/scrape/scrape",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/scrape/skillify",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/security-safety/careful",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/security-safety/cso",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/security-safety/freeze",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/security-safety/guard",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/security-safety/unfreeze",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/utility/gstack-upgrade",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/utility/office-hours",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/utility/open-gstack-browser",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/utility/retro",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "gstack/utility/setup-browser-cookies",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "marketing/meta-ads-analyzer",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -1283,11 +1781,15 @@
     },
     {
       "id": "meta-tools/autoskill",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -1298,26 +1800,35 @@
     },
     {
       "id": "meta-tools/reflect-yourself",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": true,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "meta-tools/reflect-yourself/skill-examples/phase-kickoff",
-      "score": 33,
+      "score": 20,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": false,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
@@ -1329,12 +1840,33 @@
       ]
     },
     {
+      "id": "meta-tools/writing-skills",
+      "score": 50,
+      "checks": {
+        "description_min_80": true,
+        "has_triggers": true,
+        "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
+        "has_examples": true,
+        "has_reference": false,
+        "risk_set": true
+      },
+      "issues": []
+    },
+    {
       "id": "ml-dl/pytorch-lightning",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -1345,11 +1877,15 @@
     },
     {
       "id": "ml-dl/scikit-learn",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -1360,11 +1896,15 @@
     },
     {
       "id": "ml-dl/scikit-survival",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -1375,11 +1915,15 @@
     },
     {
       "id": "ml-dl/transformers",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -1390,37 +1934,53 @@
     },
     {
       "id": "mobile/app-store-submission-packager",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "mobile/ios-testflight-github-actions",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "performance/performance-optimization",
-      "score": 100,
+      "score": 60,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -1429,24 +1989,34 @@
     },
     {
       "id": "product-growth/product-analytics-experiments",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "product-growth/product-offer-design",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -1455,26 +2025,35 @@
     },
     {
       "id": "reflect-yourself",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": true,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "reflect-yourself/skill-examples/phase-kickoff",
-      "score": 33,
+      "score": 20,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": false,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
@@ -1487,24 +2066,34 @@
     },
     {
       "id": "reliability-ops/ci-cd-quality-gates",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "reliability-ops/cross-platform-error-handling",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -1513,24 +2102,34 @@
     },
     {
       "id": "reliability-ops/dynamic-config-management",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "reliability-ops/observability-slo",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
@@ -1539,11 +2138,15 @@
     },
     {
       "id": "reliability-ops/postmortem-writing",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": true,
         "risk_set": true
@@ -1552,50 +2155,72 @@
     },
     {
       "id": "reliability-ops/serverless-debugging",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "reliability-ops/shipping-launch-checklist",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "security-appsec/api-security-testing",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "security-appsec/secure-api-design",
-      "score": 67,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": true,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
@@ -1604,39 +2229,54 @@
     },
     {
       "id": "security-appsec/skill-supply-chain-audit",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "visualization/data-viz-storytelling-healy",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "visualization/infographics",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -1647,11 +2287,15 @@
     },
     {
       "id": "visualization/matplotlib",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -1662,11 +2306,15 @@
     },
     {
       "id": "visualization/scientific-visualization",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -1677,11 +2325,15 @@
     },
     {
       "id": "visualization/seaborn",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -1692,11 +2344,15 @@
     },
     {
       "id": "voltagent",
-      "score": 33,
+      "score": 20,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": false,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
@@ -1709,731 +2365,975 @@
     },
     {
       "id": "voltagent/business-product/business-analyst",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/business-product/customer-success-manager",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/business-product/product-manager",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/business-product/project-manager",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/business-product/scrum-master",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/business-product/technical-writer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/business-product/ux-researcher",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/ai-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/data-analyst",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/data-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/data-scientist",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/database-optimizer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/llm-architect",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/machine-learning-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/ml-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/mlops-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/nlp-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/postgres-pro",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/prompt-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/data-ai/reinforcement-learning-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/dev-workflow/documentation-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/dev-workflow/git-workflow-manager",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/dev-workflow/refactoring-specialist",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/fintech-risk/fintech-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/fintech-risk/healthcare-admin",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/fintech-risk/quant-analyst",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/fintech-risk/risk-manager",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/infra/deployment-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/languages/python-pro",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/languages/sql-pro",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/orchestration/context-manager",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/orchestration/error-coordinator",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/orchestration/knowledge-synthesizer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/orchestration/multi-agent-coordinator",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/orchestration/task-distributor",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/quality-engineering/code-reviewer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/quality-engineering/debugger",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/quality-engineering/performance-engineer",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/quality-engineering/qa-expert",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/research-analysis/competitive-analyst",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/research-analysis/data-researcher",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/research-analysis/market-researcher",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/research-analysis/project-idea-validator",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/research-analysis/research-analyst",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/research-analysis/scientific-literature-researcher",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/research-analysis/search-specialist",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "voltagent/research-analysis/trend-analyst",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "writing-docs/docx",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     },
     {
       "id": "writing-docs/pdf",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -2444,37 +3344,53 @@
     },
     {
       "id": "writing-docs/pptx",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "writing-docs/prose-polish",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": true,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": false,
         "has_reference": false,
         "risk_set": true
       },
-      "issues": []
+      "issues": [
+        "low overall score"
+      ]
     },
     {
       "id": "writing-docs/scientific-writing",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -2485,11 +3401,15 @@
     },
     {
       "id": "writing-docs/sympy",
-      "score": 83,
+      "score": 50,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": true,
         "risk_set": true
@@ -2500,17 +3420,22 @@
     },
     {
       "id": "writing-docs/xlsx",
-      "score": 67,
+      "score": 40,
       "checks": {
         "description_min_80": true,
         "has_triggers": false,
         "has_usage_section": true,
+        "has_contract": false,
+        "has_phases": false,
+        "has_output_format": false,
+        "has_anti_patterns": false,
         "has_examples": true,
         "has_reference": false,
         "risk_set": true
       },
       "issues": [
-        "no triggers in description"
+        "no triggers in description",
+        "low overall score"
       ]
     }
   ]

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-27T12:21:23Z",
+  "generated_at": "2026-05-27T13:05:48Z",
   "schema_version": 2,
   "count": 178,
   "skills": [
@@ -1118,22 +1118,10 @@
       "name": "spec-driven-development",
       "domain": "core-workflow",
       "path": ".cursor/skills/core-workflow/spec-driven-development/SKILL.md",
-      "description": ">   Write a structured spec before significant implementation—objective, commands,   boundaries, testing, and success criteria. Use when starting a feature, project,   or multi-file change without a written spec.   Triggers: \"write spec\", \"PRD\", \"requirements\", \"spec before code\", \"what are we building\".",
-      "summary": ">   Write a structured spec before significant implementation—objective, commands,   boundaries, testing, and success criteria. Use when starting a feature, project,   or multi-file change without a written spec.   Triggers: \"write spec\", \"",
-      "triggers": [
-        "write spec",
-        "PRD",
-        "requirements",
-        "spec before code",
-        "what are we building"
-      ],
-      "trigger_phrases": [
-        "write spec",
-        "PRD",
-        "requirements",
-        "spec before code",
-        "what are we building"
-      ],
+      "description": ">   Write a structured spec before significant implementation—objective, commands,   boundaries, testing, and success criteria. Use when starting a feature, project,   or multi-file change without a written spec.",
+      "summary": ">   Write a structured spec before significant implementation—objective, commands,   boundaries, testing, and success criteria. Use when starting a feature, project,   or multi-file change without a written spec.",
+      "triggers": [],
+      "trigger_phrases": [],
       "risk": "low",
       "formats": [
         "cursor",

--- a/scripts/generate-quality.py
+++ b/scripts/generate-quality.py
@@ -20,6 +20,10 @@ def score_skill(skill: dict, skill_path: Path) -> dict:
     desc = skill.get("description", "")
     triggers = skill.get("triggers", [])
     has_h2 = bool(re.search(r"^##\s+", text, re.M))
+    has_contract = "## Contract" in text
+    has_phases = "## Phases" in text
+    has_output = "## Output Format" in text
+    has_anti_patterns = "## Anti-Patterns" in text
     has_examples = "Good:" in text or "Bad:" in text or "```" in text
     ref_dir = skill_path.parent
     has_reference = (ref_dir / "reference.md").exists() or any(ref_dir.glob("references/*"))
@@ -28,6 +32,10 @@ def score_skill(skill: dict, skill_path: Path) -> dict:
         "description_min_80": len(desc) >= 80,
         "has_triggers": len(triggers) >= 1,
         "has_usage_section": has_h2,
+        "has_contract": has_contract,
+        "has_phases": has_phases,
+        "has_output_format": has_output,
+        "has_anti_patterns": has_anti_patterns,
         "has_examples": has_examples,
         "has_reference": has_reference,
         "risk_set": skill.get("risk") in ("low", "medium", "high"),


### PR DESCRIPTION
## Summary
- Cập nhật  lên Content Conformance V2: frontmatter giàu hơn (, , , , ) và template thân skill chuẩn gồm: , , , , , , .
- Mở rộng  để review thêm các chiều: Contract rõ, Phases tồn tại, Output Format được định nghĩa, Anti-Patterns chỉ ra failure modes, và MECE/Related Skills.
- Nâng Wrote quality scores for 178 skills (avg 43, low 126) để track thêm các check nội dung: , , ,  nhằm phân biệt skill thiếu phần nào.
- Chuẩn hóa frontmatter của  sang V2 (version 2 + triggers list + flags), làm mẫu cho nhóm core-workflow trong các PR tiếp theo.

## Details
- Wrote quality scores for 178 skills (avg 43, low 126) hiện generate lại  với các field check mới, giữ schema_version=1 nhưng tăng số lượng checks.
- [ok] registry/skills.json
[ok] registry/bundles.json
[ok] registry sync — Registry OK (178 skills)
[ok] count: cursor vs registry — cursor=178, registry=178
[ok] count: README badge vs registry — readme=178, registry=178
[ok] count: metrics vs registry — metrics=178, registry=178
[ok] install-domain.sh
[ok] install-bundle.sh
[ok] install-skill.sh
[ok] validate-skills.py đang xanh sau khi sync lại  bằng Wrote 178 skills to /Users/viet.tran1/Documents/CakeProjects/Credit Scoring Repos/awesome-agent-skill/registry/skills.json
Bundles validated against skills registry.
- Chưa rewrite toàn bộ body của tất cả  sang heading mới, nhưng doc + quality đã sẵn sàng để drive migration dần theo domain.

## Test plan
- Wrote quality scores for 178 skills (avg 43, low 126)
- Registry OK (178 skills)
- [ok] registry/skills.json
[ok] registry/bundles.json
[ok] registry sync — Registry OK (178 skills)
[ok] count: cursor vs registry — cursor=178, registry=178
[ok] count: README badge vs registry — readme=178, registry=178
[ok] count: metrics vs registry — metrics=178, registry=178
[ok] install-domain.sh
[ok] install-bundle.sh
[ok] install-skill.sh
[ok] validate-skills.py


Made with [Cursor](https://cursor.com)