### PR TITLE
feat(catalog): YAML-friendly SKILL preview + persona bundles

### DIFF
--- a/catalog/assets/app.js
+++ b/catalog/assets/app.js
@@ -150,6 +150,31 @@ function renderCommandBox(container, command, label) {
   container.appendChild(wrap);
 }
 
+function normalizeSkillMarkdown(raw) {
+  if (!raw) return "";
+  let text = String(raw);
+
+  // Strip front-matter if present.
+  if (text.startsWith("---\n")) {
+    const idx = text.indexOf("\n---", 4);
+    if (idx !== -1) {
+      text = text.slice(idx + 4);
+    }
+  }
+
+  const hasHeading = /^#{1,6}\s/m.test(text);
+  const lines = text.split("\n").filter((ln) => ln.trim().length > 0);
+  const yamlLike =
+    !hasHeading &&
+    lines.length > 0 &&
+    lines.every((ln) => /^[\w\.\-]+\s*:/.test(ln.trim()));
+
+  if (yamlLike) {
+    return "```yaml\n" + text.trim() + "\n```";
+  }
+  return text;
+}
+
 function initSkillModal(skillContent, agentFmt) {
   const modal = document.getElementById("skill-modal");
   const titleEl = document.getElementById("modal-title");
@@ -176,8 +201,13 @@ function initSkillModal(skillContent, agentFmt) {
     githubLink.href = skillGithubUrl(skillId);
     const cmd = installSkillCmd(skillId, agentFmt());
     copyBtn.onclick = () => copyText(cmd, copyBtn);
-    if (entry && entry.markdown && typeof marked !== "undefined") {
-      bodyEl.innerHTML = marked.parse(entry.markdown);
+    if (entry && entry.markdown) {
+      const normalized = normalizeSkillMarkdown(entry.markdown);
+      if (typeof marked !== "undefined") {
+        bodyEl.innerHTML = marked.parse(normalized);
+      } else {
+        bodyEl.innerHTML = `<pre>${escapeHtml(normalized)}</pre>`;
+      }
     } else if (entry && entry.markdown) {
       bodyEl.innerHTML = `<pre>${escapeHtml(entry.markdown)}</pre>`;
     } else {
@@ -206,7 +236,6 @@ function escapeHtml(s) {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
 }
-
 function initMarketplace(skills, bundles, quality, skillContent) {
   const params = new URLSearchParams(location.search);
   let domainFilter = params.get("domain") || "";
@@ -475,9 +504,17 @@ function initMarketplace(skills, bundles, quality, skillContent) {
           <div class="badges">${tags}</div>
           <p>${(s.description || "").replace(/^>\s*/gm, "").slice(0, 180)}</p>
           <div class="card-actions">
-            ${hasPreview ? `<button class="btn btn-small" data-preview="${s.id}">Preview skill</button>` : ""}
-            <button class="btn btn-small btn-secondary" data-copy="${encodeURIComponent(installCmd)}">Copy install</button>
-            <a class="btn btn-small btn-secondary" href="${skillGithubUrl(s.id)}" target="_blank" rel="noopener">GitHub</a>
+            ${
+              hasPreview
+                ? `<button class="btn btn-small" data-preview="${s.id}">Preview skill</button>`
+                : ""
+            }
+            <button class="btn btn-small btn-secondary" data-copy="${encodeURIComponent(
+              installCmd
+            )}">Copy install</button>
+            <a class="btn btn-small btn-secondary" href="${skillGithubUrl(
+              s.id
+            )}" target="_blank" rel="noopener">GitHub</a>
           </div>
         </article>`;
       })
@@ -580,6 +617,7 @@ async function boot() {
   const skillsPayload = await skillsRes.json();
   const bundlesPayload = await bundlesRes.json();
   let quality = {};
+  let skillContent = {};
   if (qualityRes && qualityRes.ok) {
     const qdata = await qualityRes.json();
     if (Array.isArray(qdata.skills)) {
@@ -590,7 +628,6 @@ async function boot() {
       quality = qdata;
     }
   }
-  let skillContent = {};
   if (contentRes && contentRes.ok) {
     skillContent = await contentRes.json();
   }

--- a/catalog/data/bundles.json
+++ b/catalog/data/bundles.json
@@ -62,6 +62,86 @@
       "formats": ["cursor", "claude", "both"]
     },
     {
+      "id": "ai-engineer",
+      "title": "AI Engineer persona bundle",
+      "description": "Build and ship AI systems end-to-end: agents, RAG, and ML pipelines.",
+      "domains": ["ai-agent-systems", "ml-dl", "data-compute"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "software-engineer",
+      "title": "Software Engineer persona bundle",
+      "description": "Spec, implement, test, secure, and ship reliable applications.",
+      "domains": ["core-workflow", "reliability-ops", "security-appsec"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "frontend-engineer",
+      "title": "Frontend Engineer persona bundle",
+      "description": "UI accessibility, visualization, and DX-focused workflows for frontend work.",
+      "domains": ["frontend-engineering", "visualization"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "backend-engineer",
+      "title": "Backend Engineer persona bundle",
+      "description": "Secure APIs, reliability, and observability for backend services.",
+      "domains": ["security-appsec", "reliability-ops"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "sre-engineer",
+      "title": "SRE Engineer persona bundle",
+      "description": "Reliability, SLOs, incident response, and postmortems.",
+      "domains": ["reliability-ops"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "data-engineer",
+      "title": "Data Engineer persona bundle",
+      "description": "Data pipelines, scalable compute, and analytics foundations.",
+      "domains": ["data-compute", "analysis-stats", "ml-dl"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "marketing",
+      "title": "Marketing persona bundle",
+      "description": "Product analytics, experiments, storytelling, and visual assets.",
+      "domains": ["product-growth", "visualization", "writing-docs"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "ceo",
+      "title": "CEO persona bundle",
+      "description": "High-level product strategy, metrics, and decision docs.",
+      "domains": ["product-growth", "core-workflow", "writing-docs"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "cto",
+      "title": "CTO persona bundle",
+      "description": "Architecture decisions, platform reliability, and security posture.",
+      "domains": ["ai-agent-systems", "reliability-ops", "security-appsec"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "business-development",
+      "title": "Business Development persona bundle",
+      "description": "Market research, stakeholder briefs, and narrative decks.",
+      "domains": ["product-growth", "writing-docs"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
       "id": "full",
       "title": "Full Catalog",
       "description": "All top-level skill domains in this repository.",

--- a/catalog/index.html
+++ b/catalog/index.html
@@ -130,6 +130,26 @@
     </section>
   </main>
 
+  <div id="skill-preview" class="preview-backdrop" aria-hidden="true">
+    <div class="preview-modal" role="dialog" aria-modal="true" aria-labelledby="preview-title">
+      <header class="preview-header">
+        <div>
+          <h3 id="preview-title"></h3>
+          <div id="preview-id" class="skill-id"></div>
+        </div>
+        <div class="preview-header-actions">
+          <div id="preview-badges" class="badges"></div>
+          <button id="preview-close" type="button" class="btn btn-small btn-secondary">Close</button>
+        </div>
+      </header>
+      <div class="preview-toolbar">
+        <a id="preview-github" class="btn btn-small btn-secondary" href="#" target="_blank" rel="noopener">View on GitHub</a>
+        <button id="preview-copy" type="button" class="btn btn-small">Copy install</button>
+      </div>
+      <div id="preview-body" class="preview-body skill-markdown"></div>
+    </div>
+  </div>
+
   <footer class="container">
     <p>
       <a href="https://github.com/charlieviettq/awesome-agent-skill">awesome-agent-skill</a>

--- a/catalog/index.template.html
+++ b/catalog/index.template.html
@@ -130,6 +130,26 @@
     </section>
   </main>
 
+  <div id="skill-preview" class="preview-backdrop" aria-hidden="true">
+    <div class="preview-modal" role="dialog" aria-modal="true" aria-labelledby="preview-title">
+      <header class="preview-header">
+        <div>
+          <h3 id="preview-title"></h3>
+          <div id="preview-id" class="skill-id"></div>
+        </div>
+        <div class="preview-header-actions">
+          <div id="preview-badges" class="badges"></div>
+          <button id="preview-close" type="button" class="btn btn-small btn-secondary">Close</button>
+        </div>
+      </header>
+      <div class="preview-toolbar">
+        <a id="preview-github" class="btn btn-small btn-secondary" href="#" target="_blank" rel="noopener">View on GitHub</a>
+        <button id="preview-copy" type="button" class="btn btn-small">Copy install</button>
+      </div>
+      <div id="preview-body" class="preview-body skill-markdown"></div>
+    </div>
+  </div>
+
   <footer class="container">
     <p>
       <a href="https://github.com/charlieviettq/awesome-agent-skill">awesome-agent-skill</a>

--- a/registry/bundles.json
+++ b/registry/bundles.json
@@ -62,6 +62,86 @@
       "formats": ["cursor", "claude", "both"]
     },
     {
+      "id": "ai-engineer",
+      "title": "AI Engineer persona bundle",
+      "description": "Build and ship AI systems end-to-end: agents, RAG, and ML pipelines.",
+      "domains": ["ai-agent-systems", "ml-dl", "data-compute"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "software-engineer",
+      "title": "Software Engineer persona bundle",
+      "description": "Spec, implement, test, secure, and ship reliable applications.",
+      "domains": ["core-workflow", "reliability-ops", "security-appsec"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "frontend-engineer",
+      "title": "Frontend Engineer persona bundle",
+      "description": "UI accessibility, visualization, and DX-focused workflows for frontend work.",
+      "domains": ["frontend-engineering", "visualization"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "backend-engineer",
+      "title": "Backend Engineer persona bundle",
+      "description": "Secure APIs, reliability, and observability for backend services.",
+      "domains": ["security-appsec", "reliability-ops"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "sre-engineer",
+      "title": "SRE Engineer persona bundle",
+      "description": "Reliability, SLOs, incident response, and postmortems.",
+      "domains": ["reliability-ops"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "data-engineer",
+      "title": "Data Engineer persona bundle",
+      "description": "Data pipelines, scalable compute, and analytics foundations.",
+      "domains": ["data-compute", "analysis-stats", "ml-dl"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "marketing",
+      "title": "Marketing persona bundle",
+      "description": "Product analytics, experiments, storytelling, and visual assets.",
+      "domains": ["product-growth", "visualization", "writing-docs"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "ceo",
+      "title": "CEO persona bundle",
+      "description": "High-level product strategy, metrics, and decision docs.",
+      "domains": ["product-growth", "core-workflow", "writing-docs"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "cto",
+      "title": "CTO persona bundle",
+      "description": "Architecture decisions, platform reliability, and security posture.",
+      "domains": ["ai-agent-systems", "reliability-ops", "security-appsec"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
+      "id": "business-development",
+      "title": "Business Development persona bundle",
+      "description": "Market research, stakeholder briefs, and narrative decks.",
+      "domains": ["product-growth", "writing-docs"],
+      "skills": [],
+      "formats": ["cursor", "claude", "both"]
+    },
+    {
       "id": "full",
       "title": "Full Catalog",
       "description": "All top-level skill domains in this repository.",


### PR DESCRIPTION
## Summary
- Improve `SKILL.md` preview rendering by normalizing markdown/YAML before sending it to `marked`.
- Keep existing modal + bundle graph UX while wiring previews through `skill-content.json`.
- Add persona bundles (AI/Software/Data/Frontend/Backend/SRE engineer, Marketing, CEO, CTO, Business Development) driven by domains only.

## Details
- `scripts/generate-catalog.py`: reuse `generate_skill_content` to emit structured `skill-content.json` and log preview count.
- `catalog/assets/app.js`:
  - Add `normalizeSkillMarkdown()` to strip front-matter and detect YAML-shaped skills, wrapping them into fenced `yaml` blocks.
  - Use the normalizer inside `initSkillModal()` before `marked.parse`, with HTML-escaped `<pre>` fallback when `marked` is unavailable.
  - Only show "Preview skill" buttons when `skillContent[id]` exists.
- `registry/bundles.json` and `catalog/data/bundles.json`: add persona bundles that group existing domains without requiring new skills.

## Testing
- `python3 scripts/generate-catalog.py`
- `python3 scripts/skillhub.py doctor`
- Manually opened `catalog/index.html` and verified:
  - Bundle graph + filters still work.
  - Modal preview renders SKILL.md as markdown and YAML-only skills appear as nicely formatted code blocks instead of raw wrapped text.

Made with [Cursor](https://cursor.com)